### PR TITLE
chore: update helm chart versions and registry paths

### DIFF
--- a/.github/scripts/validate_charts.py
+++ b/.github/scripts/validate_charts.py
@@ -86,7 +86,7 @@ def validate_example_makefile():
         makefile_content = re.sub(r"\\\n\s*", " ", f.read())
 
     # Extract version patterns from helm upgrade commands
-    # Modified regex to support versions with suffixes like -do
+    # Modified regex to support versions with suffixes like -dogeos
     version_patterns = re.findall(
         r"helm upgrade -i ([a-zA-Z0-9-]+)\s+oci://[^\s]+\s+.*?--version=(\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)",
         makefile_content,

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -2,7 +2,7 @@ name: Lint, test and publish charts
 
 on:
   push:
-    branches: [ develop, feat/euclid-upgrade ]
+    branches: [ develop, dogeos]
     paths:
       - 'charts/**'
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       #  List chart change except scroll-sdk
       - name: Run chart-testing (list-changed)
@@ -70,7 +70,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
         # We filter here the scroll-sdk chart
       - name: Push chart to ghcr
@@ -97,7 +97,7 @@ jobs:
             helm dependencies build charts/$chart
             helm package charts/$chart
             export CHART_VERSION=$(grep 'version:' charts/$chart/Chart.yaml | head -n1 | awk '{ print $2 }')
-            helm push $chart-${CHART_VERSION}.tgz oci://ghcr.io/unifralabs/scroll-sdk/helm
+            helm push $chart-${CHART_VERSION}.tgz oci://ghcr.io/dogeos69/scroll-sdk/helm
           done
 
   helm-chart-testing-scroll-sdk:
@@ -129,7 +129,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       #  List scroll-sdk chart if it has changed
       - name: Run chart-testing (list-changed)
@@ -167,7 +167,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push chart to ghcr
         if: steps.filter.outputs.addedOrModified == 'true'
@@ -190,5 +190,5 @@ jobs:
             helm dependencies build charts/$chart
             helm package charts/$chart
             export CHART_VERSION=$(grep 'version:' charts/$chart/Chart.yaml | head -n1 | awk '{ print $2 }')
-            helm push $chart-${CHART_VERSION}.tgz oci://ghcr.io/unifralabs/scroll-sdk/helm
+            helm push $chart-${CHART_VERSION}.tgz oci://ghcr.io/dogeos69/scroll-sdk/helm
           done

--- a/.github/workflows/publish-dev-chart.yaml
+++ b/.github/workflows/publish-dev-chart.yaml
@@ -6,7 +6,7 @@ on:
       - 'charts/**'
 
 env:
-  HELM_REGISTRY: ghcr.io/unifralabs/scroll-sdk/helm/dev
+  HELM_REGISTRY: ghcr.io/dogeos69/scroll-sdk/helm/dev
 
 jobs:
   helm-chart-testing-not-scroll-sdk:
@@ -34,7 +34,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       #  List chart change except scroll-sdk
       - name: Run chart-testing (list-changed)
@@ -72,7 +72,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
         # We filter here the scroll-sdk chart
       - name: Push chart to ghcr
@@ -131,7 +131,7 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       #  List scroll-sdk chart if it has changed
       - name: Run chart-testing (list-changed)
@@ -169,11 +169,11 @@ jobs:
 
       - name: Helm registry login
         run: |
-          helm registry login ghcr.io/unifralabs/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io/dogeos69/helm/scroll-sdk --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Replace helm registry by helm/dev
         run: |
-          sed -i 's|oci://ghcr.io/unifralabs/scroll-sdk/helm|oci://ghcr.io/unifralabs/scroll-sdk/helm/dev|g' charts/scroll-sdk/Chart.yaml
+          sed -i 's|oci://ghcr.io/dogeos69/scroll-sdk/helm|oci://ghcr.io/dogeos69/scroll-sdk/helm/dev|g' charts/scroll-sdk/Chart.yaml
 
       - name: Push chart to ghcr
         if: steps.filter.outputs.addedOrModified == 'true'

--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: blockscout scroll helm charts
 name: blockscout
-version: 0.1.4-do
+version: 0.1.2-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/contracts/Chart.yaml
+++ b/charts/contracts/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: contracts helm charts
 name: contracts
-version: 0.1.3-do
+version: 0.1.2-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-bootnode/Chart.yaml
+++ b/charts/l2-bootnode/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-bootnode helm chart
 name: l2-bootnode
-version: 0.1.4-do
+version: 0.1.3-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-rpc/Chart.yaml
+++ b/charts/l2-rpc/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-rpc helm chart
 name: l2-rpc
-version: 0.1.4-do
+version: 0.1.3-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-sequencer/Chart.yaml
+++ b/charts/l2-sequencer/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-sequencer helm charts
 name: l2-sequencer
-version: 0.1.4-do
+version: 0.1.3-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/scroll-sdk/Chart.yaml
+++ b/charts/scroll-sdk/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: scroll helm charts to deploy scroll sdk
 name: scroll-sdk
-version: 0.1.10-do
+version: 0.1.4-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -30,8 +30,8 @@ dependencies:
   #   repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
   #   condition: balance-checker.enabled
   - name: blockscout
-    version: 0.1.4-do
-    repository: "oci://ghcr.io/unifralabs/scroll-sdk/helm"
+    version: 0.1.2-dogeos
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: blockscout.enabled
   # - name: blockscout-sc-verifier
   #   version: 0.1.1
@@ -50,8 +50,8 @@ dependencies:
   #   repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
   #   condition: chain-monitor.enabled
   - name: contracts
-    version: 0.1.3-do
-    repository: "oci://ghcr.io/unifralabs/scroll-sdk/helm"
+    version: 0.1.2-dogeos
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: contracts.enabled
   # - name: coordinator-api
   #   version: 0.1.2
@@ -78,16 +78,16 @@ dependencies:
   #   repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
   #   condition: l1-explorer.enabled
   - name: l2-bootnode
-    version: 0.1.4-do
-    repository: "oci://ghcr.io/unifralabs/scroll-sdk/helm"
+    version: 0.1.3-dogeos
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: l2-bootnode.enabled
   - name: l2-rpc
-    version: 0.1.4-do
-    repository: "oci://ghcr.io/unifralabs/scroll-sdk/helm"
+    version: 0.1.3-dogeos
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: l2-rpc.enabled
   - name: l2-sequencer
-    version: 0.1.4-do
-    repository: "oci://ghcr.io/unifralabs/scroll-sdk/helm"
+    version: 0.1.3-dogeos
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: l2-sequencer.enabled
   - name: postgresql
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/devnet/Makefile
+++ b/devnet/Makefile
@@ -9,7 +9,7 @@ SC_VERIFIER_TAG := $(if $(ARCH_ARM64),v1.7.0-arm,v1.7.0)
 
 bootstrap:
 		echo "Pulling helm chart..."
-		helm pull oci://ghcr.io/unifralabs/scroll-sdk/helm/scroll-sdk --version 0.1.10-do
+		helm pull oci://ghcr.io/dogeos69/scroll-sdk/helm/scroll-sdk --version 0.1.4-dogeos
 		echo "Extracting helm chart..."
 		tar -xvf *.tgz
 		$(MAKE) config

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -9,102 +9,102 @@ install:
 		--version=0.1.0 \
 		--values values/genesis.yaml
 
-	helm upgrade -i l2-sequencer-0 oci://ghcr.io/unifralabs/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
-		--version=0.1.4-do \
+	helm upgrade -i l2-sequencer-0 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
+		--version=0.1.3-dogeos \
 		--values values/l2-sequencer-production-0.yaml
 
-	helm upgrade -i l2-sequencer-1 oci://ghcr.io/unifralabs/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
-		--version=0.1.4-do \
+	helm upgrade -i l2-sequencer-1 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
+		--version=0.1.3-dogeos \
 		--values values/l2-sequencer-production-1.yaml
 
-	helm upgrade -i coordinator-api oci://ghcr.io/scroll-tech/scroll-sdk/helm/coordinator-api -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/coordinator-api-production.yaml \
-		--values values/coordinator-api-config.yaml
+	# helm upgrade -i coordinator-api oci://ghcr.io/scroll-tech/scroll-sdk/helm/coordinator-api -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/coordinator-api-production.yaml \
+	# 	--values values/coordinator-api-config.yaml
 
-	helm upgrade -i bridge-history-api oci://ghcr.io/scroll-tech/scroll-sdk/helm/bridge-history-api -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/bridge-history-api-production.yaml \
-		--values values/bridge-history-api-config.yaml
+	# helm upgrade -i bridge-history-api oci://ghcr.io/scroll-tech/scroll-sdk/helm/bridge-history-api -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/bridge-history-api-production.yaml \
+	# 	--values values/bridge-history-api-config.yaml
 
-	helm upgrade -i bridge-history-fetcher oci://ghcr.io/scroll-tech/scroll-sdk/helm/bridge-history-fetcher -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/bridge-history-fetcher-production.yaml \
-		--values values/bridge-history-fetcher-config.yaml
+	# helm upgrade -i bridge-history-fetcher oci://ghcr.io/scroll-tech/scroll-sdk/helm/bridge-history-fetcher -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/bridge-history-fetcher-production.yaml \
+	# 	--values values/bridge-history-fetcher-config.yaml
 
-	helm upgrade -i chain-monitor oci://ghcr.io/scroll-tech/scroll-sdk/helm/chain-monitor -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/chain-monitor-production.yaml \
-		--values values/chain-monitor-config.yaml
+	# helm upgrade -i chain-monitor oci://ghcr.io/scroll-tech/scroll-sdk/helm/chain-monitor -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/chain-monitor-production.yaml \
+	# 	--values values/chain-monitor-config.yaml
 
-	helm upgrade -i coordinator-cron oci://ghcr.io/scroll-tech/scroll-sdk/helm/coordinator-cron -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/coordinator-cron-production.yaml \
-		--values values/coordinator-cron-config.yaml
+	# helm upgrade -i coordinator-cron oci://ghcr.io/scroll-tech/scroll-sdk/helm/coordinator-cron -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/coordinator-cron-production.yaml \
+	# 	--values values/coordinator-cron-config.yaml
 
-	helm upgrade -i frontends oci://ghcr.io/scroll-tech/scroll-sdk/helm/frontends -n $(NAMESPACE) \
-		--version=0.1.1 \
-		--values values/frontends-production.yaml \
-		--values values/frontends-config.yaml
+	# helm upgrade -i frontends oci://ghcr.io/scroll-tech/scroll-sdk/helm/frontends -n $(NAMESPACE) \
+	# 	--version=0.1.1 \
+	# 	--values values/frontends-production.yaml \
+	# 	--values values/frontends-config.yaml
 
-	helm upgrade -i gas-oracle oci://ghcr.io/scroll-tech/scroll-sdk/helm/gas-oracle -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/gas-oracle-production.yaml \
-		--values values/gas-oracle-config.yaml
+	# helm upgrade -i gas-oracle oci://ghcr.io/scroll-tech/scroll-sdk/helm/gas-oracle -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/gas-oracle-production.yaml \
+	# 	--values values/gas-oracle-config.yaml
 
-	helm upgrade -i l2-bootnode-0 oci://ghcr.io/unifralabs/scroll-sdk/helm/l2-bootnode -n $(NAMESPACE) \
-		--version=0.1.4-do \
+	helm upgrade -i l2-bootnode-0 oci://ghcr.io/scroll-tech/dogeos69/helm/l2-bootnode -n $(NAMESPACE) \
+		--version=0.1.3-dogeos \
 		--values values/l2-bootnode-production-0.yaml
 
-	helm upgrade -i l2-bootnode-1 oci://ghcr.io/unifralabs/scroll-sdk/helm/l2-bootnode -n $(NAMESPACE) \
-		--version=0.1.4-do \
+	helm upgrade -i l2-bootnode-1 oci://ghcr.io/scroll-tech/dogeos69/helm/l2-bootnode -n $(NAMESPACE) \
+		--version=0.1.3-dogeos \
 		--values values/l2-bootnode-production-1.yaml
 
-	helm upgrade -i l2-rpc oci://ghcr.io/unifralabs/scroll-sdk/helm/l2-rpc -n $(NAMESPACE) \
-		--version=0.1.4-do \
+	helm upgrade -i l2-rpc oci://ghcr.io/scroll-tech/dogeos69/helm/l2-rpc -n $(NAMESPACE) \
+		--version=0.1.3-dogeos \
 		--values values/l2-rpc-production.yaml
 
-	helm upgrade -i rollup-explorer-backend oci://ghcr.io/scroll-tech/scroll-sdk/helm/rollup-explorer-backend -n $(NAMESPACE) \
-		--version=0.1.1 \
-		--values values/rollup-explorer-backend-production.yaml \
-		--values values/rollup-explorer-backend-config.yaml
+	# helm upgrade -i rollup-explorer-backend oci://ghcr.io/scroll-tech/scroll-sdk/helm/rollup-explorer-backend -n $(NAMESPACE) \
+	# 	--version=0.1.1 \
+	# 	--values values/rollup-explorer-backend-production.yaml \
+	# 	--values values/rollup-explorer-backend-config.yaml
 
-	helm upgrade -i rollup-node oci://ghcr.io/scroll-tech/scroll-sdk/helm/rollup-node -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/rollup-node-production.yaml \
-		--values values/rollup-node-config.yaml
+	# helm upgrade -i rollup-node oci://ghcr.io/scroll-tech/scroll-sdk/helm/rollup-node -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/rollup-node-production.yaml \
+	# 	--values values/rollup-node-config.yaml
 
-	helm upgrade -i admin-system-backend oci://ghcr.io/scroll-tech/scroll-sdk/helm/admin-system-backend -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/admin-system-backend-production.yaml \
-		--values values/admin-system-backend-config.yaml
+	# helm upgrade -i admin-system-backend oci://ghcr.io/scroll-tech/scroll-sdk/helm/admin-system-backend -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/admin-system-backend-production.yaml \
+	# 	--values values/admin-system-backend-config.yaml
 
-	helm upgrade -i admin-system-cron oci://ghcr.io/scroll-tech/scroll-sdk/helm/admin-system-cron -n $(NAMESPACE) \
-		--version=0.1.2 \
-		--values values/admin-system-cron-production.yaml \
-		--values values/admin-system-cron-config.yaml
+	# helm upgrade -i admin-system-cron oci://ghcr.io/scroll-tech/scroll-sdk/helm/admin-system-cron -n $(NAMESPACE) \
+	# 	--version=0.1.2 \
+	# 	--values values/admin-system-cron-production.yaml \
+	# 	--values values/admin-system-cron-config.yaml
 
-	helm upgrade -i admin-system-dashboard oci://ghcr.io/scroll-tech/scroll-sdk/helm/admin-system-dashboard -n $(NAMESPACE) \
-		--version=0.1.1 \
-		--values values/admin-system-dashboard-production.yaml
+	# helm upgrade -i admin-system-dashboard oci://ghcr.io/scroll-tech/scroll-sdk/helm/admin-system-dashboard -n $(NAMESPACE) \
+	# 	--version=0.1.1 \
+	# 	--values values/admin-system-dashboard-production.yaml
 
-	helm upgrade -i contracts oci://ghcr.io/unifralabs/scroll-sdk/helm/contracts -n $(NAMESPACE) \
-		--version=0.1.3-do \
+	helm upgrade -i contracts oci://ghcr.io/scroll-tech/dogeos69/helm/contracts -n $(NAMESPACE) \
+		--version=0.1.2-dogeos \
 		--values values/contracts-production.yaml \
 		--values values/scroll-common-config-contracts.yaml \
 		--values values/scroll-common-config.yaml
 
-	helm upgrade -i balance-checker oci://ghcr.io/scroll-tech/scroll-sdk/helm/balance-checker -n $(NAMESPACE) \
-		--version=0.1.1 \
-		--values values/balance-checker-production.yaml \
-		--values values/balance-checker-config.yaml
+	# helm upgrade -i balance-checker oci://ghcr.io/scroll-tech/scroll-sdk/helm/balance-checker -n $(NAMESPACE) \
+	# 	--version=0.1.1 \
+	# 	--values values/balance-checker-production.yaml \
+	# 	--values values/balance-checker-config.yaml
 
-	helm upgrade -i blockscout oci://ghcr.io/unifralabs/scroll-sdk/helm/blockscout -n $(NAMESPACE) \
-		--version=0.1.4-do \
+	helm upgrade -i blockscout oci://ghcr.io/dogeos69/scroll-sdk/helm/blockscout -n $(NAMESPACE) \
+		--version=0.1.2-dogeos \
 		--values values/blockscout-production.yaml
 
-	helm upgrade -i blockscout-sc-verifier oci://ghcr.io/unifralabs/scroll-sdk/helm/blockscout-sc-verifier -n $(NAMESPACE) \
-		--version=0.1.1
+	# helm upgrade -i blockscout-sc-verifier oci://ghcr.io/scroll-tech/scroll-sdk/helm/blockscout-sc-verifier -n $(NAMESPACE) \
+	# 	--version=0.1.1
 
 
 install-l1-devnet:
@@ -116,26 +116,26 @@ delete:
 	helm delete -n $(NAMESPACE) scroll-common
 	helm delete -n $(NAMESPACE) l2-sequencer-0
 	helm delete -n $(NAMESPACE) l2-sequencer-1
-	helm delete -n $(NAMESPACE) coordinator-api
-	helm delete -n $(NAMESPACE) bridge-history-api
-	helm delete -n $(NAMESPACE) bridge-history-fetcher
-	helm delete -n $(NAMESPACE) chain-monitor
-	helm delete -n $(NAMESPACE) coordinator-cron
-	helm delete -n $(NAMESPACE) frontends
-	helm delete -n $(NAMESPACE) gas-oracle
+	# helm delete -n $(NAMESPACE) coordinator-api
+	# helm delete -n $(NAMESPACE) bridge-history-api
+	# helm delete -n $(NAMESPACE) bridge-history-fetcher
+	# helm delete -n $(NAMESPACE) chain-monitor
+	# helm delete -n $(NAMESPACE) coordinator-cron
+	# helm delete -n $(NAMESPACE) frontends
+	# helm delete -n $(NAMESPACE) gas-oracle
 	helm delete -n $(NAMESPACE) l2-bootnode-0
 	helm delete -n $(NAMESPACE) l2-bootnode-1
 	helm delete -n $(NAMESPACE) l2-rpc
-	helm delete -n $(NAMESPACE) rollup-explorer-backend
-	helm delete -n $(NAMESPACE) rollup-node
-	helm delete -n $(NAMESPACE) admin-system-backend
-	helm delete -n $(NAMESPACE) admin-system-cron
-	helm delete -n $(NAMESPACE) admin-system-dashboard
+	# helm delete -n $(NAMESPACE) rollup-explorer-backend
+	# helm delete -n $(NAMESPACE) rollup-node
+	# helm delete -n $(NAMESPACE) admin-system-backend
+	# helm delete -n $(NAMESPACE) admin-system-cron
+	# helm delete -n $(NAMESPACE) admin-system-dashboard
 	helm delete -n $(NAMESPACE) contracts
 	helm delete -n $(NAMESPACE) scroll-monitor
-	helm delete -n $(NAMESPACE) balance-checker
+	# helm delete -n $(NAMESPACE) balance-checker
 	helm delete -n $(NAMESPACE) blockscout
-	helm delete -n $(NAMESPACE) blockscout-sc-verifier
+	# helm delete -n $(NAMESPACE) blockscout-sc-verifier
 
 delete-l1-devnet:
 	helm delete -n $(NAMESPACE) l1-devnet

--- a/examples/anvil-fund-accounts.sh
+++ b/examples/anvil-fund-accounts.sh
@@ -5,14 +5,15 @@ read_config() {
     yq eval "$1" charts/scroll-sdk/config.toml
 }
 
-L1_RPC_URL="l1-2.devnet.scroll.tech"
+L1_RPC_URL="l1-devnet.scroll.tech"
 
 # Array of addresses
 addresses=(
   "$(read_config '.accounts.L1_COMMIT_SENDER_ADDR')"
   "$(read_config '.accounts.L1_FINALIZE_SENDER_ADDR')"
   "$(read_config '.accounts.L1_GAS_ORACLE_SENDER_ADDR')"
-  "0x98110937b5D6C5FCB0BA99480e585D2364e9809C"
+  "$(read_config '.accounts.DEPLOYER_ADDR')"
+  "$(read_config '.accounts.OWNER_ADDR')"
 )
 
 # Loop through each address and call the curl command


### PR DESCRIPTION
- Updated the helm chart versions for blockscout, contracts, l2-bootnode, l2-rpc, l2-sequencer, and scroll-sdk to reflect the new naming convention with the suffix `-dogeos`.
- Changed the helm registry paths from `ghcr.io/unifralabs` to `ghcr.io/dogeos69` across various workflow files and Makefiles for consistency.
- Adjusted the regex in `validate_charts.py` to accommodate version suffixes like `-dogeos`.