### PR TITLE
Pin blockscout image pull policy

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: blockscout scroll helm charts
 name: blockscout
-version: 0.1.5-dogeos
+version: 0.1.6-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -1,6 +1,6 @@
 # blockscout
 
-![Version: 0.1.5-dogeos](https://img.shields.io/badge/Version-0.1.5--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.6-dogeos](https://img.shields.io/badge/Version-0.1.6--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 blockscout scroll helm charts
 
@@ -37,7 +37,7 @@ Kubernetes: `>=1.22.0-0`
 | blockscout-stack.blockscout.env.INDEXER_SCROLL_L2_MESSENGER_START_BLOCK | int | `0` |  |
 | blockscout-stack.blockscout.env.SCROLL_L2_CURIE_UPGRADE_BLOCK | int | `0` |  |
 | blockscout-stack.blockscout.envFrom[0].configMapRef.name | string | `"blockscout-env"` |  |
-| blockscout-stack.blockscout.image.pullPolicy | string | `"IfNotPresent"` |  |
+| blockscout-stack.blockscout.image.pullPolicy | string | `"Always"` |  |
 | blockscout-stack.blockscout.image.repository | string | `"ghcr.io/blockscout/blockscout-scroll"` |  |
 | blockscout-stack.blockscout.image.tag | string | `"8.0.2"` |  |
 | blockscout-stack.blockscout.ingress.annotations."nginx.ingress.kubernetes.io/cors-allow-headers" | string | `"updated-gas-oracle, Content-Type, Authorization"` |  |
@@ -68,6 +68,7 @@ Kubernetes: `>=1.22.0-0`
 | blockscout-stack.frontend.env.NEXT_PUBLIC_NETWORK_LOGO | string | `"https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/scroll.svg"` |  |
 | blockscout-stack.frontend.env.NEXT_PUBLIC_NETWORK_LOGO_DARK | string | `"https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/scroll-dark.svg"` |  |
 | blockscout-stack.frontend.env.NEXT_PUBLIC_OG_IMAGE_URL | string | `"https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/og-images/scroll-sepolia.png"` |  |
+| blockscout-stack.frontend.image.pullPolicy | string | `"Always"` |  |
 | blockscout-stack.frontend.image.tag | string | `"v1.38.2"` |  |
 | blockscout-stack.frontend.ingress.annotations."nginx.ingress.kubernetes.io/cors-allow-headers" | string | `"updated-gas-oracle, Content-Type, Authorization"` |  |
 | blockscout-stack.frontend.ingress.annotations."nginx.ingress.kubernetes.io/cors-allow-methods" | string | `"GET, POST, OPTIONS"` |  |

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -8,7 +8,7 @@ blockscout-stack:
   blockscout:
     image:
       repository: ghcr.io/blockscout/blockscout-scroll
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
       tag: 8.0.2
 
     env:
@@ -61,6 +61,7 @@ blockscout-stack:
 
   frontend:
     image:
+      pullPolicy: Always
       tag: v1.38.2
 
     env:

--- a/charts/scroll-sdk/Chart.yaml
+++ b/charts/scroll-sdk/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: scroll helm charts to deploy scroll sdk for dogeos
 name: scroll-sdk
-version: 0.1.9-dogeos
+version: 0.1.10-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -30,7 +30,7 @@ dependencies:
   #   repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
   #   condition: balance-checker.enabled
   - name: blockscout
-    version: 0.1.5-dogeos
+    version: 0.1.6-dogeos
     repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: blockscout.enabled
   # - name: blockscout-sc-verifier

--- a/charts/scroll-sdk/README.md
+++ b/charts/scroll-sdk/README.md
@@ -1,6 +1,6 @@
 # scroll-sdk
 
-![Version: 0.1.9-dogeos](https://img.shields.io/badge/Version-0.1.10--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.10-dogeos](https://img.shields.io/badge/Version-0.1.10--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 scroll helm charts to deploy scroll sdk for dogeos
 
@@ -18,7 +18,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://ghcr.io/dogeos69/scroll-sdk/helm | blockscout | 0.1.5-dogeos |
+| oci://ghcr.io/dogeos69/scroll-sdk/helm | blockscout | 0.1.6-dogeos |
 | oci://ghcr.io/dogeos69/scroll-sdk/helm | contracts | 0.1.7-dogeos |
 | oci://ghcr.io/dogeos69/scroll-sdk/helm | gas-oracle | 0.1.3-dogeos |
 | oci://ghcr.io/dogeos69/scroll-sdk/helm | l2-bootnode | 0.1.3-dogeos |

--- a/devnet/Makefile
+++ b/devnet/Makefile
@@ -9,7 +9,7 @@ SC_VERIFIER_TAG := $(if $(ARCH_ARM64),v1.7.0-arm,v1.7.0)
 
 bootstrap:
 		echo "Pulling helm chart..."
-		helm pull oci://ghcr.io/dogeos69/scroll-sdk/helm/scroll-sdk --version 0.1.9-dogeos
+		helm pull oci://ghcr.io/dogeos69/scroll-sdk/helm/scroll-sdk --version 0.1.10-dogeos
 		echo "Extracting helm chart..."
 		tar -xvf *.tgz
 		$(MAKE) config

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -103,7 +103,7 @@ install-l1-devnet:
 
 install-blockscout:
 	helm upgrade -i blockscout oci://ghcr.io/dogeos69/scroll-sdk/helm/blockscout -n $(NAMESPACE) \
-		--version=0.1.5-dogeos \
+		--version=0.1.6-dogeos \
 		--values values/blockscout-production.yaml
 
 	helm upgrade -i blockscout-sc-verifier oci://ghcr.io/dogeos69/scroll-sdk/helm/blockscout-sc-verifier -n $(NAMESPACE) \


### PR DESCRIPTION
It doesn't support specifying a digest, so this might be the only way to minimize the risk of different pods running different images.