### PR TITLE
Update additional charts to use external-secrets-lib 0.0.4 from dogeo…

### DIFF
--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: celestia-node
 description: A Helm chart for deploying Celestia light node on Kubernetes
-version: 0.1.3
+version: 0.1.4
 appVersion: "v0.22.0-mocha"
 maintainers:
   - name: Celestia
     email: support@celestia.org
 dependencies:
   - name: external-secrets-lib
-    repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
-    version: 0.0.3
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
+    version: 0.0.4

--- a/charts/cubesigner-signer/Chart.yaml
+++ b/charts/cubesigner-signer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubesigner-signer
 description: A Helm chart for the DOGEOS CubeSigner Attestation Signer
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -14,5 +14,5 @@ dependencies:
     repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
     version: 1.5.1
   - name: external-secrets-lib
-    repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
-    version: 0.0.3
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
+    version: 0.0.4

--- a/charts/dogeos-deposit-processor/Chart.yaml
+++ b/charts/dogeos-deposit-processor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dogeos-deposit-processor
 description: A Helm chart for the DogeOS Bridge deposit processor
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -14,5 +14,5 @@ dependencies:
     repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
     version: 1.5.1
   - name: external-secrets-lib
-    repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
-    version: 0.0.3
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
+    version: 0.0.4

--- a/charts/gas-oracle/Chart.yaml
+++ b/charts/gas-oracle/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: gas-oracle helm charts
 name: gas-oracle
-version: 0.1.4-dogeos
+version: 0.1.5-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-bootnode/Chart.yaml
+++ b/charts/l2-bootnode/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-bootnode helm chart
 name: l2-bootnode
-version: 0.1.4-dogeos
+version: 0.1.5-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-rpc/Chart.yaml
+++ b/charts/l2-rpc/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-rpc helm chart
 name: l2-rpc
-version: 0.1.4-dogeos
+version: 0.1.5-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-sequencer/Chart.yaml
+++ b/charts/l2-sequencer/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-sequencer helm charts
 name: l2-sequencer
-version: 0.1.4-dogeos
+version: 0.1.5-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/rollup-node/Chart.yaml
+++ b/charts/rollup-node/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: rollup-node helm charts
 name: rollup-node
-version: 0.1.4-dogeos
+version: 0.1.5-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/scroll-common/Chart.yaml
+++ b/charts/scroll-common/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: scroll helm charts to deploy common scripts and configuration
 name: scroll-common
-version: 0.1.0
+version: 0.1.1-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -14,5 +14,5 @@ keywords:
 home: https://github.com/scroll-tech/scroll-sdk
 dependencies:
   - name: external-secrets-lib
-    repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
-    version: 0.0.3
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
+    version: 0.0.4

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -11,7 +11,7 @@ install-dogecoin:
 
 install-celestia:
 	helm upgrade -i celestia-testnet oci://ghcr.io/dogeos69/scroll-sdk/helm/celestia-node -n $(NAMESPACE) \
-		--version=0.1.3 \
+		--version=0.1.4 \
 		--values values/celestia-node-production.yaml
 
 install-l1-devnet:
@@ -24,8 +24,8 @@ install-scroll-core:
 		--version=0.1.4-dogeos \
 		--values values/scroll-monitor-production.yaml
 
-	helm upgrade -i scroll-common oci://ghcr.io/scroll-tech/scroll-sdk/helm/scroll-common -n $(NAMESPACE) \
-		--version=0.1.0 \
+	helm upgrade -i scroll-common oci://ghcr.io/dogeos69/scroll-sdk/helm/scroll-common -n $(NAMESPACE) \
+		--version=0.1.1-dogeos \
 		--values values/genesis.yaml
 
 	helm upgrade -i grafana-alloy grafana/alloy -n $(NAMESPACE) \
@@ -37,23 +37,23 @@ install-scroll-core:
 		--values values/metrics-exporter-production.yaml
 
 	helm upgrade -i l2-sequencer-0 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--values values/l2-sequencer-production-0.yaml
 
 	helm upgrade -i l2-sequencer-1 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--values values/l2-sequencer-production-1.yaml
 
 	helm upgrade -i l2-bootnode-0 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-bootnode -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--values values/l2-bootnode-production-0.yaml
 
 	helm upgrade -i l2-bootnode-1 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-bootnode -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--values values/l2-bootnode-production-1.yaml
 
 	helm upgrade -i l2-rpc oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-rpc -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--values values/l2-rpc-production.yaml
 
 install-contracts:
@@ -71,7 +71,7 @@ install-dogeos-da:
 
 install-rollup-node:
 	helm upgrade -i rollup-node oci://ghcr.io/dogeos69/scroll-sdk/helm/rollup-node -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--set image.tag=latest \
 		--set image.repository=dogeos69/rollup-relayer \
 		--set image.pullPolicy=Always \
@@ -85,28 +85,28 @@ install-rollup-node:
 
 install-gas-oracle:
 	helm upgrade -i gas-oracle oci://ghcr.io/dogeos69/scroll-sdk/helm/gas-oracle -n $(NAMESPACE) \
-		--version=0.1.4-dogeos \
+		--version=0.1.5-dogeos \
 		--values values/gas-oracle-production.yaml \
 		--values values/gas-oracle-config.yaml
 
 install-deposit-processor:
 	helm upgrade -i dogeos-deposit-processor oci://ghcr.io/dogeos69/scroll-sdk/helm/dogeos-deposit-processor -n $(NAMESPACE) \
-		--version=0.1.3 \
+		--version=0.1.4 \
 		--values values/dogeos-deposit-processor-production.yaml
 
 install-cubesigner-signers:
 	helm upgrade -i cubesigner-signer-0 oci://ghcr.io/dogeos69/scroll-sdk/helm/cubesigner-signer -n $(NAMESPACE) \
-	 	--version=0.1.1 \
+	 	--version=0.1.2 \
 		--set image.tag=test-amd64 \
 		--set image.pullPolicy=Always \
 		--values values/cubesigner-signer-production-0.yaml
 	helm upgrade -i cubesigner-signer-1 oci://ghcr.io/dogeos69/scroll-sdk/helm/cubesigner-signer -n $(NAMESPACE) \
-		--version=0.1.1 \
+		--version=0.1.2 \
 		--set image.tag=test-amd64 \
 		--set image.pullPolicy=Always \
 		--values values/cubesigner-signer-production-1.yaml
 	helm upgrade -i cubesigner-signer-2 oci://ghcr.io/dogeos69/scroll-sdk/helm/cubesigner-signer -n $(NAMESPACE) \
-		--version=0.1.1 \
+		--version=0.1.2 \
 		--set image.tag=test-amd64 \
 		--set image.pullPolicy=Always \
 		--values values/cubesigner-signer-production-2.yaml


### PR DESCRIPTION
…s69 registry - Update celestia-node: 0.1.3 → 0.1.4 - Update scroll-common: 0.1.0 → 0.1.1-dogeos (moved to dogeos69 registry) - Update cubesigner-signer: 0.1.1 → 0.1.2 - Update dogeos-deposit-processor: 0.1.3 → 0.1.4 - Update l2-rpc: 0.1.4-dogeos → 0.1.5-dogeos - Update l2-sequencer: 0.1.4-dogeos → 0.1.5-dogeos - Update l2-bootnode: 0.1.4-dogeos → 0.1.5-dogeos - Update rollup-node: 0.1.4-dogeos → 0.1.5-dogeos - Update gas-oracle: 0.1.4-dogeos → 0.1.5-dogeos - Update Makefile.example with all new chart versions All charts now use external-secrets-lib 0.0.4 with external-secrets.io/v1 API