### PR TITLE
Replace l1-devnet RPC with l1-interface

### DIFF
--- a/charts/l1-interface/Chart.yaml
+++ b/charts/l1-interface/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: l1-interface
 description: A Helm chart for the DogeOS L1 interface
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "0.0.1"
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l1-interface/README.md
+++ b/charts/l1-interface/README.md
@@ -1,6 +1,6 @@
 # l1-interface
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for the DogeOS L1 interface
 
@@ -29,6 +29,7 @@ Kubernetes: `>=1.22.0-0`
 | configMaps.env.data.DOGEOS_L1_INTERFACE_DATABASE_URL | string | `"sqlite:///data/l1-interface.sqlite"` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_GENESIS_JSON_PATH | string | `"/app/genesis/genesis.json"` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_HEALTH_LISTEN_ADDRESS | string | `"0.0.0.0:9090"` |  |
+| configMaps.env.data.DOGEOS_L1_INTERFACE_SEQUENCER_GENESIS_MODE | string | `"true"` |  |
 | configMaps.env.enabled | bool | `true` |  |
 | controller.replicas | int | `1` |  |
 | controller.strategy | string | `"RollingUpdate"` |  |
@@ -71,6 +72,10 @@ Kubernetes: `>=1.22.0-0`
 | resources.requests.cpu | string | `"200m"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
 | service.main.enabled | bool | `true` |  |
+| service.main.ports.admin.enabled | bool | `true` |  |
+| service.main.ports.admin.port | int | `9091` |  |
+| service.main.ports.admin.protocol | string | `"TCP"` |  |
+| service.main.ports.admin.targetPort | int | `9091` |  |
 | service.main.ports.beacon.enabled | bool | `true` |  |
 | service.main.ports.beacon.port | int | `5052` |  |
 | service.main.ports.beacon.protocol | string | `"TCP"` |  |

--- a/charts/l1-interface/values.yaml
+++ b/charts/l1-interface/values.yaml
@@ -31,6 +31,11 @@ service:
         port: 9090
         targetPort: 9090
         protocol: TCP
+      admin:
+        enabled: true
+        port: 9091
+        targetPort: 9091
+        protocol: TCP
 
 defaultProbes: &default_probes
   enabled: true
@@ -84,6 +89,7 @@ configMaps:
       DOGEOS_L1_INTERFACE_HEALTH_LISTEN_ADDRESS: "0.0.0.0:9090"
       DOGEOS_L1_INTERFACE_GENESIS_JSON_PATH: "/app/genesis/genesis.json"
       DOGEOS_L1_INTERFACE_DATABASE_URL: "sqlite:///data/l1-interface.sqlite"
+      DOGEOS_L1_INTERFACE_SEQUENCER_GENESIS_MODE: "true"
 
 envFrom:
   - secretRef:

--- a/charts/l1-interface/values/production.yaml
+++ b/charts/l1-interface/values/production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "dogeos69/l1-interface"
   pullPolicy: "Always"
-  tag: "072325-02"
+  tag: "072425-01"
 
 # Direct environment variables
 env:

--- a/charts/l1-interface/values/production.yaml
+++ b/charts/l1-interface/values/production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "dogeos69/l1-interface"
   pullPolicy: "Always"
-  tag: "071425-00"
+  tag: "072325-02"
 
 # Direct environment variables
 env:
@@ -19,6 +19,7 @@ configMaps:
       DOGEOS_L1_INTERFACE_SCROLL_MESSENGER_ADDRESS: ""                        # L1_SCROLL_MESSENGER_PROXY_ADDR
       DOGEOS_L1_INTERFACE_L1_GENESIS_BLOCK: "8208200"                         # DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__START_HEIGHT
       DOGEOS_L1_INTERFACE_L2_MOAT_CONTRACT_ADDRESS: ""                        # L2_MOAT_PROXY_ADDR
+      DOGEOS_L1_INTERFACE_L2_MESSENGER_ADDRESS: ""                            # L2_DOGEOS_MESSENGER_PROXY_ADDR
       DOGEOS_L1_INTERFACE_DEPOSIT_GAS_LIMIT: "500000"                         # predefined
       DOGEOS_L1_INTERFACE_L1_GAS_LIMIT: "30000000"                            # predefined
       DOGEOS_L1_INTERFACE_L1_BASE_FEE_PER_GAS: "1000000000"                   # genesis.BASE_FEE_PER_GAS

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -26,7 +26,7 @@ install-celestia:
 
 install-l1-interface:
 	helm upgrade -i l1-interface oci://ghcr.io/dogeos69/scroll-sdk/helm/l1-interface -n $(NAMESPACE) \
-		--version=0.0.4 \
+		--version=0.0.5 \
 		--values values/l1-interface-production.yaml
 
 install-l1-devnet:
@@ -43,6 +43,8 @@ install-scroll-core:
 	helm upgrade -i scroll-common oci://ghcr.io/dogeos69/scroll-sdk/helm/scroll-common -n $(NAMESPACE) \
 		--version=0.1.1-dogeos \
 		--values values/genesis.yaml
+
+	$(MAKE) install-l1-interface
 
 	helm upgrade -i grafana-alloy grafana/alloy -n $(NAMESPACE) \
 		--version=1.0.2 \
@@ -169,10 +171,13 @@ install-testnet-activity-helper:
 		--version=0.1.1 \
 		--values values/testnet-activity-helper-production.yaml
 
+start-l1-sync:
+	kubectl exec -n $(NAMESPACE) $$(kubectl get pod -n $(NAMESPACE) -l app.kubernetes.io/name=rollup-node -o jsonpath='{.items[0].metadata.name}') -- \
+		curl -X POST http://l1-interface:9091/disable-genesis-hold
+
 install-all:
 	$(MAKE) install-dogecoin
 	$(MAKE) install-celestia
-	$(MAKE) install-l1-interface
 	$(MAKE) install-l1-devnet
 	$(MAKE) install-scroll-core
 	kubectl wait --for=condition=Ready --timeout=360s pod -l app.kubernetes.io/instance=l1-devnet -n $(NAMESPACE)
@@ -184,13 +189,15 @@ install-all:
 	kubectl wait --for=condition=Ready --timeout=360s pod -l app.kubernetes.io/instance=dogeos-da -n $(NAMESPACE)
 	$(MAKE) install-rollup-node
 	$(MAKE) install-gas-oracle
-	$(MAKE) install-deposit-processor
+#    $(MAKE) install-deposit-processor
 	$(MAKE) install-cubesigner-signers
 	$(MAKE) install-tso
+	kubectl wait --for=condition=Ready --timeout=360s pod -l app.kubernetes.io/instance=tso-service -n $(NAMESPACE)
 	$(MAKE) install-withdrawal-processor
 	$(MAKE) install-blockscout
 	$(MAKE) install-frontends
 	$(MAKE) install-testnet-activity-helper
+	$(MAKE) start-l1-sync
 
 delete-all:
 	helm delete -n $(NAMESPACE) scroll-common || true
@@ -211,7 +218,7 @@ delete-all:
 	helm delete -n $(NAMESPACE) withdrawal-processor || true
 	helm delete -n $(NAMESPACE) tso-service || true
 	$(MAKE) delete-cubesigner-signers || true
-	helm delete -n $(NAMESPACE) dogeos-deposit-processor || true
+#    helm delete -n $(NAMESPACE) dogeos-deposit-processor || true
 	helm delete -n $(NAMESPACE) dogeos-da || true
 	helm delete -n $(NAMESPACE) l1-devnet || true
 	helm delete -n $(NAMESPACE) l1-interface || true

--- a/examples/config.toml.example
+++ b/examples/config.toml.example
@@ -1,5 +1,6 @@
 [general]
 
+DOGEOS_L1_RPC_ENDPOINT = "http://l1-interface:8545"
 L1_RPC_ENDPOINT = "http://l1-devnet:8545"
 L1_RPC_ENDPOINT_WEBSOCKET = "ws://l1-devnet:8546"
 L2_RPC_ENDPOINT = "http://l2-rpc:8545"

--- a/examples/values/l1-interface-production.yaml
+++ b/examples/values/l1-interface-production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "dogeos69/l1-interface"
   pullPolicy: "Always"
-  tag: "072325-02"
+  tag: "072425-01"
 
 # Direct environment variables
 env:

--- a/examples/values/l1-interface-production.yaml
+++ b/examples/values/l1-interface-production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "dogeos69/l1-interface"
   pullPolicy: "Always"
-  tag: "071425-00"
+  tag: "072325-02"
 
 # Direct environment variables
 env:
@@ -19,6 +19,7 @@ configMaps:
       DOGEOS_L1_INTERFACE_SCROLL_MESSENGER_ADDRESS: ""                        # L1_SCROLL_MESSENGER_PROXY_ADDR
       DOGEOS_L1_INTERFACE_L1_GENESIS_BLOCK: "8208200"                         # DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__START_HEIGHT
       DOGEOS_L1_INTERFACE_L2_MOAT_CONTRACT_ADDRESS: ""                        # L2_MOAT_PROXY_ADDR
+      DOGEOS_L1_INTERFACE_L2_MESSENGER_ADDRESS: ""                            # L2_DOGEOS_MESSENGER_PROXY_ADDR
       DOGEOS_L1_INTERFACE_DEPOSIT_GAS_LIMIT: "500000"                         # predefined
       DOGEOS_L1_INTERFACE_L1_GAS_LIMIT: "30000000"                            # predefined
       DOGEOS_L1_INTERFACE_L1_BASE_FEE_PER_GAS: "1000000000"                   # genesis.BASE_FEE_PER_GAS


### PR DESCRIPTION
* Replace l1-devnet RPC with l1-interface in most of the services, e.g. l2-sequencer, l2-rpc, l2-bootnode, etc.

* not changed for the following two services:
1. rollup-node
2. contracts

* Not changed in scroll-sdk-cli commands:
1. helper activity
2. helper fund-accounts
3. gen-rpc
4. test contracts
5. test e2e