### PR TITLE
update celestia-node and supoort trustedHeight

### DIFF
--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: celestia-node
 description: A Helm chart for deploying Celestia light node on Kubernetes
-version: 0.1.5
+version: 0.1.6
 appVersion: "v0.22.2-mocha"
 maintainers:
   - name: Celestia

--- a/charts/celestia-node/README.md
+++ b/charts/celestia-node/README.md
@@ -1,6 +1,6 @@
 # celestia-node
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: v0.22.2-mocha](https://img.shields.io/badge/AppVersion-v0.22.2--mocha-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: v0.22.2-mocha](https://img.shields.io/badge/AppVersion-v0.22.2--mocha-informational?style=flat-square)
 
 A Helm chart for deploying Celestia light node on Kubernetes
 
@@ -24,7 +24,7 @@ A Helm chart for deploying Celestia light node on Kubernetes
 | core.rpc_url | string | `"rpc-mocha.pops.one"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/celestiaorg/celestia-node"` |  |
-| image.tag | string | `"v0.22.2-mocha"` |  |
+| image.tag | string | `"v0.24.1-mocha"` |  |
 | ingress.annotations."cert-manager.io/cluster-issuer" | string | `"letsencrypt-prod"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/ssl-redirect" | string | `"true"` |  |
 | ingress.className | string | `"nginx"` |  |
@@ -61,6 +61,7 @@ A Helm chart for deploying Celestia light node on Kubernetes
 | share.discovery.sampleSize | int | `8` |  |
 | share.light.samplingPeriod | string | `"1s"` |  |
 | share.light.samplingRange | int | `128` |  |
+| share.light.trustedHash | string | `nil` |  |
 | share.light.trustedHeight | int | `0` |  |
 | share.light.trustedPeers | list | `[]` |  |
 | share.light.waitForCheckpoint | bool | `false` |  |

--- a/charts/celestia-node/templates/configmap.yaml
+++ b/charts/celestia-node/templates/configmap.yaml
@@ -70,8 +70,9 @@ data:
       AdvertiseInterval = "1h0m0s"
 
     [Header]
-    TrustedHash = ""
-    TrustedPeers = []
+    TrustedHash = "{{ .Values.share.light.trustedHash }}"
+    TrustedPeers = {{ .Values.share.light.trustedPeers | toJson }}
+    TrustedHeight = {{ printf "%d" (int .Values.share.light.trustedHeight) }}
     [Header.Store]
       StoreCacheSize = 512
       IndexCacheSize = 2048
@@ -90,5 +91,9 @@ data:
     SamplingRange = {{ default 128 .Values.share.samplingRange }}
     ConcurrencyLimit = {{ default 8 .Values.share.discovery.concurrencyLimit }}
     BackgroundStoreInterval = "10m0s"
+    {{- if and .Values.share.light.trustedHeight (gt (int .Values.share.light.trustedHeight) 0) }}
+    SampleFrom = {{ printf "%d" (int .Values.share.light.trustedHeight) }}
+    {{- else }}
     SampleFrom = 1
+    {{- end }}
     SampleTimeout = "2m40s"

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -21,6 +21,8 @@ share:
     concurrencyLimit: 8
   light:
     trustedPeers: []
+    # The trusted hash of the light node, corresponding to the trusted height.
+    trustedHash: null
     trustedHeight: 0
     samplingRange: 128
     samplingPeriod: "1s"
@@ -28,7 +30,7 @@ share:
 
 image:
   repository: "ghcr.io/celestiaorg/celestia-node"
-  tag: "v0.22.2-mocha"
+  tag: "v0.24.1-mocha"
   pullPolicy: IfNotPresent
 
 storage:

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -21,7 +21,7 @@ install-dogecoin:
 
 install-celestia:
 	helm upgrade -i celestia-testnet oci://ghcr.io/dogeos69/scroll-sdk/helm/celestia-node -n $(NAMESPACE) \
-		--version=0.1.5 \
+		--version=0.1.6 \
 		--values values/celestia-node-production.yaml
 
 install-l1-interface:

--- a/examples/values/celestia-node-production.yaml
+++ b/examples/values/celestia-node-production.yaml
@@ -21,15 +21,11 @@ share:
     concurrencyLimit: 8
   light:
     trustedPeers: []
-    trustedHeight: 0
+    trustedHeight: 7410000
+    trustedHash: "3A23865AE9BDB52D775259431B114552F02DECBB0C56D799FDFB6DFB21534285"
     samplingRange: 128
     samplingPeriod: "1s"
     waitForCheckpoint: false
-
-image:
-  repository: "ghcr.io/celestiaorg/celestia-node"
-  tag: "v0.23.3-mocha"
-  pullPolicy: IfNotPresent
 
 storage:
   size: "220Gi"


### PR DESCRIPTION
1. This is a relatively standalone PR, as it only upgrades Celestia node version.
2. Enabled the TrustedHeight feature, so new deployments shouldn't require a long syncing time