### PR TITLE
Update geth to 5.9.2 and correct flags per release note

### DIFF
--- a/charts/l2-bootnode/Chart.yaml
+++ b/charts/l2-bootnode/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-bootnode helm chart
 name: l2-bootnode
-version: 0.1.11-dogeos
+version: 0.1.12-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-bootnode/README.md
+++ b/charts/l2-bootnode/README.md
@@ -1,6 +1,6 @@
 # l2-bootnode
 
-![Version: 0.1.11-dogeos](https://img.shields.io/badge/Version-0.1.11--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.12-dogeos](https://img.shields.io/badge/Version-0.1.12--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 l2-bootnode helm chart
 
@@ -25,7 +25,7 @@ Kubernetes: `>=1.22.0-0`
 |-----|------|---------|-------------|
 | command[0] | string | `"bash"` |  |
 | command[1] | string | `"-c"` |  |
-| command[2] | string | `"geth --datadir \"/l2geth/data\" init /l2geth/genesis/genesis.json && echo ${L2GETH_NODEKEY} > /l2geth/data/geth/nodekey && echo \"[Node.P2P] StaticNodes = $L2GETH_PEER_LIST\" > \"/l2geth/config.toml\" && geth --datadir \"/l2geth/data\" --port \"$L2GETH_P2P_PORT\" --nodiscover --syncmode full --networkid \"$CHAIN_ID\" --maxpeers \"$L2GETH_MAX_PEERS\" --netrestrict \"$L2GETH_NETRESTRICT\" --nat \"$L2GETH_NAT\" --bootnodes \"\" --scroll-mpt --rollup.verify --da.blob.beaconnode \"$L2GETH_DA_BLOB_BEACON_NODE\" --gcmode full --config \"/l2geth/config.toml\" --cache.noprefetch --verbosity 3 --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 $METRICS_FLAGS --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" --txpool.pricelimit \"$L2GETH_MIN_GAS_PRICE\" $LOCALS_FLAG --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --rpc.gascap 0 --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --metrics --metrics.expensive --gossip.enablebroadcasttoall\t$L2GETH_EXTRA_PARAMS"` |  |
+| command[2] | string | `"geth --datadir \"/l2geth/data\" init /l2geth/genesis/genesis.json && echo ${L2GETH_NODEKEY} > /l2geth/data/geth/nodekey && echo \"[Node.P2P] StaticNodes = $L2GETH_PEER_LIST\" > \"/l2geth/config.toml\" && geth --datadir \"/l2geth/data\" --port \"$L2GETH_P2P_PORT\" --nodiscover --syncmode full --networkid \"$CHAIN_ID\" --maxpeers \"$L2GETH_MAX_PEERS\" --netrestrict \"$L2GETH_NETRESTRICT\" --nat \"$L2GETH_NAT\" --bootnodes \"\" --scroll-mpt --rollup.verify --da.blob.beaconnode \"$L2GETH_DA_BLOB_BEACON_NODE\" --gcmode archive --config \"/l2geth/config.toml\" --cache.noprefetch --cache.snapshot=0 --snapshot=false --gpo.maxprice 500000000 --verbosity 3 --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 $METRICS_FLAGS --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" $LOCALS_FLAG --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --rpc.gascap 0 --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --metrics --metrics.expensive --gossip.enablebroadcasttoall\t$L2GETH_EXTRA_PARAMS"` |  |
 | controller.replicas | int | `1` |  |
 | controller.strategy | string | `"RollingUpdate"` |  |
 | controller.type | string | `"statefulset"` |  |
@@ -56,7 +56,7 @@ Kubernetes: `>=1.22.0-0`
 | global.nameOverride | string | `"l2-bootnode"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"scrolltech/l2geth"` |  |
-| image.tag | string | `"scroll-v5.8.74"` |  |
+| image.tag | string | `"scroll-v5.9.2"` |  |
 | initContainers.wait-for-l1.command[0] | string | `"/bin/sh"` |  |
 | initContainers.wait-for-l1.command[1] | string | `"-c"` |  |
 | initContainers.wait-for-l1.command[2] | string | `"/wait-for-l1.sh $L2GETH_L1_ENDPOINT"` |  |

--- a/charts/l2-bootnode/values.yaml
+++ b/charts/l2-bootnode/values.yaml
@@ -11,7 +11,7 @@ controller:
 image:
   repository: scrolltech/l2geth
   pullPolicy: IfNotPresent
-  tag: scroll-v5.8.74
+  tag: scroll-v5.9.2
 
 env:
   - name: L2GETH_L1_WATCHER_CONFIRMATIONS
@@ -48,15 +48,16 @@ command:
     --bootnodes \"\" \
     --scroll-mpt \
     --rollup.verify --da.blob.beaconnode \"$L2GETH_DA_BLOB_BEACON_NODE\" \
-    --gcmode full \
+    --gcmode archive \
     --config \"/l2geth/config.toml\" \
-    --cache.noprefetch \
+    --cache.noprefetch --cache.snapshot=0 --snapshot=false \
+    --gpo.maxprice 500000000 \
     --verbosity 3 \
     --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 \
     $METRICS_FLAGS \
     --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" \
     --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" \
-    --txpool.pricelimit \"$L2GETH_MIN_GAS_PRICE\" $LOCALS_FLAG \
+    $LOCALS_FLAG \
     --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" \
     --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --rpc.gascap 0 \
     --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" \

--- a/charts/l2-rpc/Chart.yaml
+++ b/charts/l2-rpc/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-rpc helm chart
 name: l2-rpc
-version: 0.1.10-dogeos
+version: 0.1.11-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-rpc/README.md
+++ b/charts/l2-rpc/README.md
@@ -1,6 +1,6 @@
 # l2-rpc
 
-![Version: 0.1.10-dogeos](https://img.shields.io/badge/Version-0.1.10--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.11-dogeos](https://img.shields.io/badge/Version-0.1.11--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 l2-rpc helm chart
 
@@ -25,7 +25,7 @@ Kubernetes: `>=1.22.0-0`
 |-----|------|---------|-------------|
 | command[0] | string | `"bash"` |  |
 | command[1] | string | `"-c"` |  |
-| command[2] | string | `"geth --datadir \"/l2geth/data\" init /l2geth/genesis/genesis.json && echo \"[Node.P2P] StaticNodes = $L2GETH_PEER_LIST\" > \"/l2geth/config.toml\" && geth --datadir \"/l2geth/data\" --port \"$L2GETH_P2P_PORT\" --nodiscover --syncmode full --networkid \"$CHAIN_ID\" --config \"/l2geth/config.toml\" --http --http.port \"$L2GETH_RPC_HTTP_PORT\" --http.addr \"0.0.0.0\" --http.vhosts=\"*\" --http.corsdomain '*' --http.api \"eth,scroll,net,web3,debug\" --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 --ws --ws.port \"$L2GETH_RPC_WS_PORT\" --ws.addr \"0.0.0.0\" --ws.api \"eth,scroll,net,web3,debug\" $METRICS_FLAGS --scroll-mpt --rollup.verify --da.blob.beaconnode \"$L2GETH_DA_BLOB_BEACON_NODE\" --gcmode archive --cache.noprefetch --verbosity 3 --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" --txpool.pricelimit \"$L2GETH_MIN_GAS_PRICE\" $LOCALS_FLAG --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --rpc.gascap 0 --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --gpo.percentile 20 --gpo.blocks 100 --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" --metrics --metrics.expensive --gossip.enablebroadcasttoall $L2GETH_EXTRA_PARAMS"` |  |
+| command[2] | string | `"geth --datadir \"/l2geth/data\" init /l2geth/genesis/genesis.json && echo \"[Node.P2P] StaticNodes = $L2GETH_PEER_LIST\" > \"/l2geth/config.toml\" && geth --datadir \"/l2geth/data\" --port \"$L2GETH_P2P_PORT\" --nodiscover --syncmode full --networkid \"$CHAIN_ID\" --config \"/l2geth/config.toml\" --http --http.port \"$L2GETH_RPC_HTTP_PORT\" --http.addr \"0.0.0.0\" --http.vhosts=\"*\" --http.corsdomain '*' --http.api \"eth,scroll,net,web3,debug\" --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 --ws --ws.port \"$L2GETH_RPC_WS_PORT\" --ws.addr \"0.0.0.0\" --ws.api \"eth,scroll,net,web3,debug\" $METRICS_FLAGS --scroll-mpt --rollup.verify --da.blob.beaconnode \"$L2GETH_DA_BLOB_BEACON_NODE\" --gcmode archive --cache.noprefetch --cache.snapshot=0 --snapshot=false --gpo.maxprice 500000000 --verbosity 3 --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" $LOCALS_FLAG --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --rpc.gascap 0 --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --gpo.percentile 20 --gpo.blocks 100 --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" --metrics --metrics.expensive --gossip.enablebroadcasttoall $L2GETH_EXTRA_PARAMS"` |  |
 | controller.replicas | int | `1` |  |
 | controller.strategy | string | `"RollingUpdate"` |  |
 | controller.type | string | `"statefulset"` |  |
@@ -62,7 +62,7 @@ Kubernetes: `>=1.22.0-0`
 | global.nameOverride | string | `"l2-rpc"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"scrolltech/l2geth"` |  |
-| image.tag | string | `"scroll-v5.8.74"` |  |
+| image.tag | string | `"scroll-v5.9.2"` |  |
 | ingress.main.annotations | object | `{}` |  |
 | ingress.main.enabled | bool | `true` |  |
 | ingress.main.hosts[0].host | string | `"l2-rpc.scrollsdk"` |  |

--- a/charts/l2-rpc/values.yaml
+++ b/charts/l2-rpc/values.yaml
@@ -11,7 +11,7 @@ controller:
 image:
   repository: scrolltech/l2geth
   pullPolicy: IfNotPresent
-  tag: scroll-v5.8.74
+  tag: scroll-v5.9.2
 
 service:
   main:
@@ -99,11 +99,12 @@ command:
     --scroll-mpt \
     --rollup.verify --da.blob.beaconnode \"$L2GETH_DA_BLOB_BEACON_NODE\" \
     --gcmode archive \
-    --cache.noprefetch \
+    --cache.noprefetch --cache.snapshot=0 --snapshot=false \
+    --gpo.maxprice 500000000 \
     --verbosity 3 \
     --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" \
     --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" \
-    --txpool.pricelimit \"$L2GETH_MIN_GAS_PRICE\" $LOCALS_FLAG \
+    $LOCALS_FLAG \
     --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --rpc.gascap 0 \
     --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --gpo.percentile 20 --gpo.blocks 100 \
     --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" \

--- a/charts/l2-sequencer/Chart.yaml
+++ b/charts/l2-sequencer/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2-sequencer helm charts
 name: l2-sequencer
-version: 0.1.9-dogeos
+version: 0.1.10-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-sequencer/README.md
+++ b/charts/l2-sequencer/README.md
@@ -1,6 +1,6 @@
 # l2-sequencer
 
-![Version: 0.1.9-dogeos](https://img.shields.io/badge/Version-0.1.9--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.10-dogeos](https://img.shields.io/badge/Version-0.1.10--dogeos-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 l2-sequencer helm charts
 
@@ -25,7 +25,7 @@ Kubernetes: `>=1.22.0-0`
 |-----|------|---------|-------------|
 | command[0] | string | `"bash"` |  |
 | command[1] | string | `"-c"` |  |
-| command[2] | string | `"mkdir -p /l2geth/data/keystore && mkdir -p /l2geth/data/geth && echo \"[Node.P2P] StaticNodes = $L2GETH_PEER_LIST\" > \"/l2geth/config.toml\" && echo ${L2GETH_PASSWORD} > /l2geth/password && echo ${L2GETH_KEYSTORE}  > /l2geth/data/keystore/keystore.json && echo ${L2GETH_NODEKEY} > /l2geth/data/geth/nodekey && geth --datadir \"/l2geth/data\" init /l2geth/genesis/genesis.json && geth --datadir \"/l2geth/data\" --port \"$L2GETH_P2P_PORT\" --nodiscover --syncmode full --networkid \"$CHAIN_ID\" --config \"/l2geth/config.toml\" --http --http.port \"$L2GETH_RPC_HTTP_PORT\" --http.addr \"0.0.0.0\" --http.vhosts=\"*\" --http.corsdomain \"*\" --http.api \"eth,scroll,net,web3,debug\" --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 --ws --ws.port \"$L2GETH_RPC_WS_PORT\" --ws.addr \"0.0.0.0\" --ws.api \"eth,scroll,net,web3,debug\" --unlock \"$L2GETH_SIGNER_ADDRESS\" --password \"/l2geth/password\" --allow-insecure-unlock --mine --scroll-mpt --gcmode archive --cache.noprefetch --verbosity ${VERBOSITY} --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" --txpool.pricelimit \"$L2GETH_MIN_GAS_PRICE\" $LOCALS_FLAG --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --miner.gaslimit \"$L2GETH_MINER_GASLIMIT\" --rpc.gascap 0 --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --gpo.percentile 20 --gpo.blocks 100 --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" --metrics --metrics.expensive --gossip.disabletxbroadcast --cache.snapshot=0 --snapshot=false $L2GETH_EXTRA_PARAMS"` |  |
+| command[2] | string | `"mkdir -p /l2geth/data/keystore && mkdir -p /l2geth/data/geth && echo \"[Node.P2P] StaticNodes = $L2GETH_PEER_LIST\" > \"/l2geth/config.toml\" && echo ${L2GETH_PASSWORD} > /l2geth/password && echo ${L2GETH_KEYSTORE}  > /l2geth/data/keystore/keystore.json && echo ${L2GETH_NODEKEY} > /l2geth/data/geth/nodekey && geth --datadir \"/l2geth/data\" init /l2geth/genesis/genesis.json && geth --datadir \"/l2geth/data\" --port \"$L2GETH_P2P_PORT\" --nodiscover --syncmode full --networkid \"$CHAIN_ID\" --config \"/l2geth/config.toml\" --http --http.port \"$L2GETH_RPC_HTTP_PORT\" --http.addr \"0.0.0.0\" --http.vhosts=\"*\" --http.corsdomain \"*\" --http.api \"eth,scroll,net,web3,debug\" --pprof --pprof.addr \"0.0.0.0\" --pprof.port 6060 --ws --ws.port \"$L2GETH_RPC_WS_PORT\" --ws.addr \"0.0.0.0\" --ws.api \"eth,scroll,net,web3,debug\" --unlock \"$L2GETH_SIGNER_ADDRESS\" --password \"/l2geth/password\" --allow-insecure-unlock --mine --scroll-mpt --gcmode archive --cache.noprefetch --cache.snapshot=0 --snapshot=false --gpo.maxprice 500000000 --verbosity ${VERBOSITY} --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" $LOCALS_FLAG --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --miner.gaslimit \"$L2GETH_MINER_GASLIMIT\" --rpc.gascap 0 --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --gpo.percentile 20 --gpo.blocks 100 --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" --metrics --metrics.expensive --gossip.disabletxbroadcast $L2GETH_EXTRA_PARAMS"` |  |
 | controller.replicas | int | `1` |  |
 | controller.strategy | string | `"RollingUpdate"` |  |
 | controller.type | string | `"statefulset"` |  |
@@ -62,7 +62,7 @@ Kubernetes: `>=1.22.0-0`
 | global.nameOverride | string | `"l2-sequencer"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"scrolltech/l2geth"` |  |
-| image.tag | string | `"scroll-v5.8.74"` |  |
+| image.tag | string | `"scroll-v5.9.2"` |  |
 | initContainers.wait-for-l1.command[0] | string | `"/bin/sh"` |  |
 | initContainers.wait-for-l1.command[1] | string | `"-c"` |  |
 | initContainers.wait-for-l1.command[2] | string | `"/wait-for-l1.sh $L2GETH_L1_ENDPOINT"` |  |

--- a/charts/l2-sequencer/values.yaml
+++ b/charts/l2-sequencer/values.yaml
@@ -11,7 +11,7 @@ controller:
 image:
   repository: scrolltech/l2geth
   pullPolicy: IfNotPresent
-  tag: scroll-v5.8.74
+  tag: scroll-v5.9.2
 
 env:
   - name: L2GETH_L1_WATCHER_CONFIRMATIONS
@@ -62,17 +62,17 @@ command:
     --unlock \"$L2GETH_SIGNER_ADDRESS\" --password \"/l2geth/password\" --allow-insecure-unlock --mine \
     --scroll-mpt \
     --gcmode archive \
-    --cache.noprefetch \
+    --cache.noprefetch --cache.snapshot=0 --snapshot=false \
+    --gpo.maxprice 500000000 \
     --verbosity ${VERBOSITY} \
     --txpool.globalqueue \"$L2GETH_GLOBAL_QUEUE\" --txpool.accountqueue \"$L2GETH_ACCOUNT_QUEUE\" \
     --txpool.globalslots \"$L2GETH_GLOBAL_SLOTS\" --txpool.accountslots \"$L2GETH_ACCOUNT_SLOTS\" \
-    --txpool.pricelimit \"$L2GETH_MIN_GAS_PRICE\" $LOCALS_FLAG \
+    $LOCALS_FLAG \
     --miner.gasprice \"$L2GETH_MIN_GAS_PRICE\" --miner.gaslimit \"$L2GETH_MINER_GASLIMIT\" --rpc.gascap 0 \
     --gpo.ignoreprice \"$L2GETH_MIN_GAS_PRICE\" --gpo.percentile 20 --gpo.blocks 100 \
     --l1.endpoint \"$L2GETH_L1_ENDPOINT\" --l1.confirmations \"$L2GETH_L1_WATCHER_CONFIRMATIONS\" --l1.sync.startblock \"$L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK\" \
     --metrics --metrics.expensive \
     --gossip.disabletxbroadcast \
-    --cache.snapshot=0 --snapshot=false \
     $L2GETH_EXTRA_PARAMS"
 
 initContainers:

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -27,7 +27,7 @@ install-celestia:
 install-l1-interface:
 	helm upgrade -i l1-interface oci://ghcr.io/dogeos69/scroll-sdk/helm/l1-interface -n $(NAMESPACE) \
 		--version=0.0.6 \
-		--set image.tag=073125-00 \
+		--set image.tag=081225-00 \
 		--values values/l1-interface-production.yaml
 
 install-l1-devnet:
@@ -61,25 +61,25 @@ install-scroll-core:
 
 install-l2-rpc:
 	helm upgrade -i l2-rpc oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-rpc -n $(NAMESPACE) \
-		--version=0.1.10-dogeos \
+		--version=0.1.11-dogeos \
 		--values values/l2-rpc-production.yaml
 
 install-l2-sequencer:
 	helm upgrade -i l2-sequencer-0 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
-		--version=0.1.9-dogeos \
+		--version=0.1.10-dogeos \
 		--values values/l2-sequencer-production-0.yaml
 
 	helm upgrade -i l2-sequencer-1 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-sequencer -n $(NAMESPACE) \
-		--version=0.1.9-dogeos \
+		--version=0.1.10-dogeos \
 		--values values/l2-sequencer-production-1.yaml
 
 install-l2-bootnode:
 	helm upgrade -i l2-bootnode-0 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-bootnode -n $(NAMESPACE) \
-		--version=0.1.11-dogeos \
+		--version=0.1.12-dogeos \
 		--values values/l2-bootnode-production-0.yaml
 
 	helm upgrade -i l2-bootnode-1 oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-bootnode -n $(NAMESPACE) \
-		--version=0.1.11-dogeos \
+		--version=0.1.12-dogeos \
 		--values values/l2-bootnode-production-1.yaml
 
 install-contracts:


### PR DESCRIPTION
1. upgrade geth to 5.9.2 for l2-sequencer, l2-rpc, l2-bootnode

2. Modified the following flags according to release note:
```
        a. removed since 5.8.52+:
        --txpool.pricelimit
        
        b. modified since 5.8.52+:
        --gcmode archive
        
        c. added since 5.8.52+:
        --cache.snapshot=0
        --snapshot=false
        --gpo.maxprice 500000000
```

Fresh redeployment has been done after above changes.