### PR TITLE
Use internal blockbook for l1-interface and withdrawal-processor

### DIFF
--- a/charts/blockbook/Chart.yaml
+++ b/charts/blockbook/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: blockbook
 description: Deploy Blockbook for Dogecoin in Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "latest"
 maintainers:
   - name: DogeOS69

--- a/charts/blockbook/README.md
+++ b/charts/blockbook/README.md
@@ -1,6 +1,6 @@
 # blockbook
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Deploy Blockbook for Dogecoin in Kubernetes
 
@@ -23,7 +23,6 @@ Deploy Blockbook for Dogecoin in Kubernetes
 | affinity | object | `{}` |  |
 | blockbook.network | string | `"testnet"` |  |
 | blockbook.rpcUrl | string | `"http://dogecoin-testnet:44555"` |  |
-| blockbook.rpcUser | string | `"user"` |  |
 | externalSecrets | object | `{}` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"docker.io/dogeos69/blockbook"` |  |

--- a/charts/blockbook/templates/deployment.yaml
+++ b/charts/blockbook/templates/deployment.yaml
@@ -39,12 +39,24 @@ spec:
           env:
             - name: RPC_URL
               value: {{ .Values.blockbook.rpcUrl | quote }}
-            - name: RPC_USER
-              value: {{ .Values.blockbook.rpcUser | quote }}
             {{- if .Values.blockbook.messageQueueBinding }}
             - name: MESSAGE_QUEUE_BINDING
               value: {{ .Values.blockbook.messageQueueBinding | quote }}
             {{- end }}
+            - name: RPC_USER
+              {{- if .Values.blockbook.rpcUser }}
+              value: {{ .Values.blockbook.rpcUser | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  {{- $secretName := "" }}
+                  {{- range $key, $value := .Values.externalSecrets }}
+                  {{- $secretName = $key }}
+                  {{- break }}
+                  {{- end }}
+                  name: {{ $secretName }}
+                  key: DOGECOIN_RPC_USER
+              {{- end }}
             - name: RPC_PASS
               {{- if .Values.blockbook.rpcPassword }}
               value: {{ .Values.blockbook.rpcPassword | quote }}
@@ -57,7 +69,7 @@ spec:
                   {{- break }}
                   {{- end }}
                   name: {{ $secretName }}
-                  key: password
+                  key: DOGECOIN_RPC_PASSWORD
               {{- end }}
           volumeMounts:
             - name: blockbook-data

--- a/charts/blockbook/values.yaml
+++ b/charts/blockbook/values.yaml
@@ -5,7 +5,6 @@ replicaCount: 1
 blockbook:
   network: testnet
   rpcUrl: "http://dogecoin-testnet:44555"
-  rpcUser: "user"
 
 # External Secrets configuration (recommended for production)
 externalSecrets: {}

--- a/charts/l1-interface/Chart.yaml
+++ b/charts/l1-interface/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: l1-interface
 description: A Helm chart for the DogeOS L1 interface
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.1"
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l1-interface/README.md
+++ b/charts/l1-interface/README.md
@@ -1,6 +1,6 @@
 # l1-interface
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for the DogeOS L1 interface
 
@@ -27,6 +27,7 @@ Kubernetes: `>=1.22.0-0`
 | configMaps.env.data.DOGEOS_L1_INTERFACE_API_BIND_ADDRESS | string | `"0.0.0.0:8545"` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_BEACON_API_LISTEN_ADDRESS | string | `"0.0.0.0:5052"` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_DATABASE_URL | string | `"sqlite:///data/l1-interface.sqlite"` |  |
+| configMaps.env.data.DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY | string | `""` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_GENESIS_JSON_PATH | string | `"/app/genesis/genesis.json"` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_HEALTH_LISTEN_ADDRESS | string | `"0.0.0.0:9090"` |  |
 | configMaps.env.data.DOGEOS_L1_INTERFACE_SEQUENCER_GENESIS_MODE | string | `"true"` |  |

--- a/charts/l1-interface/values.yaml
+++ b/charts/l1-interface/values.yaml
@@ -90,6 +90,7 @@ configMaps:
       DOGEOS_L1_INTERFACE_GENESIS_JSON_PATH: "/app/genesis/genesis.json"
       DOGEOS_L1_INTERFACE_DATABASE_URL: "sqlite:///data/l1-interface.sqlite"
       DOGEOS_L1_INTERFACE_SEQUENCER_GENESIS_MODE: "true"
+      DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY: ""
 
 envFrom:
   - secretRef:

--- a/charts/l1-interface/values/production.yaml
+++ b/charts/l1-interface/values/production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "dogeos69/l1-interface"
   pullPolicy: "Always"
-  tag: "072425-01"
+  tag: "082725-00"
 
 # Direct environment variables
 env:
@@ -33,7 +33,7 @@ configMaps:
       DOGEOS_L1_INTERFACE_RUN_MIGRATIONS: "true"                              # predefined
 
       DOGEOS_L1_INTERFACE_DOGECOIN_RPC__URL: "http://dogecoin-testnet:44555"  # DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL
-      DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_URL: ""                     # DOGEOS_WITHDRAWAL_BLOCKBOOK_URL
+      DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_URL: "http://blockbook-testnet:19139"      # default
 
       DOGEOS_L1_INTERFACE_DOGECOIN_INDEXER__START_HEIGHT: "8208200"           # DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__START_HEIGHT
       DOGEOS_L1_INTERFACE_DOGECOIN_INDEXER__CONFIRMATIONS: "6"                # predefined
@@ -63,10 +63,6 @@ externalSecrets:
           key: "dogeos/l1-interface-secret-env"
           property: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__PASS"
         secretKey: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__PASS"
-      - remoteRef:
-          key: "dogeos/l1-interface-secret-env"
-          property: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY"
-        secretKey: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY"
     refreshInterval: "2m"
     serviceAccount: "external-secrets"
 

--- a/charts/withdrawal-processor/Chart.yaml
+++ b/charts/withdrawal-processor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: withdrawal-processor
 description: A Helm chart for the DOGEOS Withdrawal Processor
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.1.0"
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/withdrawal-processor/README.md
+++ b/charts/withdrawal-processor/README.md
@@ -1,6 +1,6 @@
 # withdrawal-processor
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for the DOGEOS Withdrawal Processor
 
@@ -87,7 +87,7 @@ Kubernetes: `>=1.22.0-0`
 | env[3].name | string | `"DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL"` |  |
 | env[3].value | string | `"https://testnet.doge.xyz"` |  |
 | env[4].name | string | `"DOGEOS_WITHDRAWAL_BLOCKBOOK_URL"` |  |
-| env[4].value | string | `"https://dogebook-testnet.nownodes.io"` |  |
+| env[4].value | string | `"http://blockbook-testnet:19139"` |  |
 | env[5].name | string | `"DOGEOS_WITHDRAWAL_TSO_URL"` |  |
 | env[5].value | string | `"http://127.0.0.1:3001"` |  |
 | env[6].name | string | `"DOGEOS_WITHDRAWAL_BRIDGE_ADDRESS"` |  |

--- a/charts/withdrawal-processor/values.yaml
+++ b/charts/withdrawal-processor/values.yaml
@@ -60,7 +60,7 @@ env:
   # - name: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS
   #   value: ""    # Sensitive: Override in production, preferably via secrets
   - name: DOGEOS_WITHDRAWAL_BLOCKBOOK_URL
-    value: "https://dogebook-testnet.nownodes.io"
+    value: "http://blockbook-testnet:19139"   # default
   # - name: DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY
   #   value: ""    # Sensitive: Override in production, preferably via secrets
   - name: DOGEOS_WITHDRAWAL_TSO_URL

--- a/charts/withdrawal-processor/values/production.yaml
+++ b/charts/withdrawal-processor/values/production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: dogeos69/withdrawal-processor
   pullPolicy: Always
-  tag: v0.1.0-beta
+  tag: 082825-01
 
 env:
   # Top-level settings
@@ -16,7 +16,7 @@ env:
   - name: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL
     value: "https://your-mainnet-dogecoin-rpc-url" # FIXME: Update with production Dogecoin RPC URL
   - name: DOGEOS_WITHDRAWAL_BLOCKBOOK_URL
-    value: "https://your-mainnet-blockbook-url" # FIXME: Update with production Blockbook URL (e.g., Nownodes mainnet)
+    value: "http://blockbook-testnet:19139"    # default
   - name: DOGEOS_WITHDRAWAL_TSO_URL
     value: "http://tso-service.your-namespace.svc.cluster.local:3000" # FIXME: Update with actual TSO service URL in K8s
   - name: DOGEOS_WITHDRAWAL_BRIDGE_ADDRESS
@@ -109,10 +109,6 @@ externalSecrets:
           key: dogeos/withdrawal-processor
           property: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS
         secretKey: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS
-      - remoteRef:
-          key: dogeos/withdrawal-processor
-          property: DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY
-        secretKey: DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY
       - remoteRef:
           key: dogeos/withdrawal-processor
           property: DOGEOS_WITHDRAWAL_FEE_SIGNER_KEY

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -21,7 +21,7 @@ install-dogecoin:
 
 install-blockbook:
 	helm upgrade -i blockbook-testnet oci://ghcr.io/dogeos69/scroll-sdk/helm/blockbook -n $(NAMESPACE) \
-		--version=0.1.3 \
+		--version=0.1.4 \
 		--values values/blockbook-production.yaml
 
 install-celestia:
@@ -31,8 +31,7 @@ install-celestia:
 
 install-l1-interface:
 	helm upgrade -i l1-interface oci://ghcr.io/dogeos69/scroll-sdk/helm/l1-interface -n $(NAMESPACE) \
-		--version=0.0.6 \
-		--set image.tag=082425-00 \
+		--version=0.0.7 \
 		--values values/l1-interface-production.yaml
 
 install-l1-devnet:
@@ -147,8 +146,7 @@ install-tso:
 
 install-withdrawal-processor:
 	helm upgrade -i withdrawal-processor oci://ghcr.io/dogeos69/scroll-sdk/helm/withdrawal-processor -n $(NAMESPACE) \
-		--version=0.1.7 \
-		--set image.tag=082625-00 \
+		--version=0.1.8 \
 		--values values/withdrawal-processor-production.yaml
 
 install-blockscout:
@@ -178,6 +176,7 @@ start-l1-sync:
 install-all:
 	$(MAKE) install-dogecoin
 	$(MAKE) install-celestia
+	$(MAKE) install-blockbook
 	$(MAKE) install-scroll-core
 	kubectl wait --for=condition=Ready --timeout=360s pod -l app.kubernetes.io/instance=l1-interface -n $(NAMESPACE)
 #	scrollsdk helper fund-accounts -i -f 2 -d

--- a/examples/values/blockbook-production.yaml
+++ b/examples/values/blockbook-production.yaml
@@ -5,7 +5,6 @@
 blockbook:
   network: testnet
   rpcUrl: "http://dogecoin-testnet:44555"  # Internal K8s service for testnet
-  rpcUser: "user"                          # Production RPC username
   blockHeight: "10150000" # Starting block height for syncing
 
 # Enable ingress for external access
@@ -28,12 +27,17 @@ ingress:
 # RPC Password Configuration for Production
 # Use External Secrets to fetch password from AWS Secrets Manager
 externalSecrets:
-  dogecoin-production:
-    provider: aws
-    serviceAccount: external-secrets
-    refreshInterval: 2m
+  blockbook-secret-env:
     data:
       - remoteRef:
-          key: dogecoin/rpc-credentials
-          property: DOGECOIN_RPC_PASSWORD
-        secretKey: password
+          key: "dogeos/blockbook-secret-env"
+          property: "DOGECOIN_RPC_USER"
+        secretKey: "DOGECOIN_RPC_USER"
+      - remoteRef:
+          key: "dogeos/blockbook-secret-env"
+          property: "DOGECOIN_RPC_PASSWORD"
+        secretKey: "DOGECOIN_RPC_PASSWORD"
+    provider: "aws"
+    serviceAccount: "external-secrets"
+    refreshInterval: "2m"
+

--- a/examples/values/l1-interface-production.yaml
+++ b/examples/values/l1-interface-production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "dogeos69/l1-interface"
   pullPolicy: "Always"
-  tag: "072425-01"
+  tag: "082725-00"
 
 # Direct environment variables
 env:
@@ -33,7 +33,7 @@ configMaps:
       DOGEOS_L1_INTERFACE_RUN_MIGRATIONS: "true"                              # predefined
 
       DOGEOS_L1_INTERFACE_DOGECOIN_RPC__URL: "http://dogecoin-testnet:44555"  # DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL
-      DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_URL: ""                     # DOGEOS_WITHDRAWAL_BLOCKBOOK_URL
+      DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_URL: "http://blockbook-testnet:19139"      # default
 
       DOGEOS_L1_INTERFACE_DOGECOIN_INDEXER__START_HEIGHT: "8208200"           # DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__START_HEIGHT
       DOGEOS_L1_INTERFACE_DOGECOIN_INDEXER__CONFIRMATIONS: "6"                # predefined
@@ -63,10 +63,6 @@ externalSecrets:
           key: "dogeos/l1-interface-secret-env"
           property: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__PASS"
         secretKey: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__PASS"
-      - remoteRef:
-          key: "dogeos/l1-interface-secret-env"
-          property: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY"
-        secretKey: "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY"
     refreshInterval: "2m"
     serviceAccount: "external-secrets"
 

--- a/examples/values/withdrawal-processor-production.yaml
+++ b/examples/values/withdrawal-processor-production.yaml
@@ -3,7 +3,7 @@
 image:
   repository: dogeos69/withdrawal-processor
   pullPolicy: Always
-  tag: v0.1.0-beta
+  tag: 082825-01
 
 env:
   # Top-level settings
@@ -16,7 +16,7 @@ env:
   - name: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL
     value: "https://your-mainnet-dogecoin-rpc-url" # FIXME: Update with production Dogecoin RPC URL
   - name: DOGEOS_WITHDRAWAL_BLOCKBOOK_URL
-    value: "https://your-mainnet-blockbook-url" # FIXME: Update with production Blockbook URL (e.g., Nownodes mainnet)
+    value: "http://blockbook-testnet:19139"    # default
   - name: DOGEOS_WITHDRAWAL_TSO_URL
     value: "http://tso-service.your-namespace.svc.cluster.local:3000" # FIXME: Update with actual TSO service URL in K8s
   - name: DOGEOS_WITHDRAWAL_BRIDGE_ADDRESS
@@ -109,10 +109,6 @@ externalSecrets:
           key: dogeos/withdrawal-processor
           property: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS
         secretKey: DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS
-      - remoteRef:
-          key: dogeos/withdrawal-processor
-          property: DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY
-        secretKey: DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY
       - remoteRef:
           key: dogeos/withdrawal-processor
           property: DOGEOS_WITHDRAWAL_FEE_SIGNER_KEY


### PR DESCRIPTION
1. use secret for dogecoin rpc user/password in blockbook service
2. leave empty of l1_config.endpoint in rollup-config.yaml
3. use internal blockbook service for l1-interface and withdrawal-processor

note: NowNodes API KEY is still required during bridge initialization.