### PR TITLE
fix(preinstalls): bump chart version 0.1.0-dogeos → 0.1.1-dogeos

### DIFF
--- a/charts/preinstalls/Chart.yaml
+++ b/charts/preinstalls/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Deploys the standard preinstalled contracts (Multicall3, CreateX, Permit2, Safe v1.3.0, ERC-4337) to a freshly launched DogeOS L2.
 name: preinstalls
-version: 0.1.0-dogeos
+version: 0.1.1-dogeos
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/scroll-sdk/Chart.yaml
+++ b/charts/scroll-sdk/Chart.yaml
@@ -94,7 +94,7 @@ dependencies:
     version: 15.5.0
     condition: postgresql.enabled
   - name: preinstalls
-    version: 0.1.0-dogeos
+    version: 0.1.1-dogeos
     repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
     condition: preinstalls.enabled
   - name: rollup-explorer-backend

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -150,7 +150,7 @@ install-blockscout:
 
 install-preinstalls:
 	helm upgrade -i preinstalls oci://ghcr.io/dogeos69/scroll-sdk/helm/preinstalls -n $(NAMESPACE) \
-		--version=0.1.0-dogeos \
+		--version=0.1.1-dogeos \
 		--values values/preinstalls-production.yaml
 	kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s pod -l app.kubernetes.io/instance=preinstalls -n $(NAMESPACE)
 


### PR DESCRIPTION
## Why

The chart-publish CI step on \`v0.3.0-develop\` (post-merge of #103) is failing with:

\`\`\`
Error: failed to perform "Exists" on destination ... preinstalls/blobs/...:
response status code 403: Forbidden
\`\`\`

[Failed run #25514482205](https://github.com/DogeOS69/scroll-sdk/actions/runs/25514482205/job/74881878666)

Cause: \`dogeos69/scroll-sdk/helm/preinstalls:0.1.0-dogeos\` was already published to GHCR (manually or by an earlier publish with different perms), and the current workflow's \`GITHUB_TOKEN\` can't HEAD or overwrite that existing blob.

## Fix

Bump the chart version to \`0.1.1-dogeos\` so the publish writes to a fresh OCI tag with no pre-existing blob conflict. Three files updated to keep references in sync:

- \`charts/preinstalls/Chart.yaml\` — chart's own version
- \`charts/scroll-sdk/Chart.yaml\` — preinstalls dependency declaration in the parent chart
- \`examples/Makefile.example\` — \`install-preinstalls\` helm reference

\`validate_charts.py\` passes locally (\`✅ All checks passed!\`).

## Note

This PR was originally part of #103 but landed on the \`preinstalls\` branch a few minutes after the squash merge of #103, so it didn't make it into \`v0.3.0-develop\`. Cherry-picked onto a fresh branch and submitted separately.

## Followup (not blocking this PR)

The 403 is also fixable on the package-permissions side: in https://github.com/orgs/DogeOS69/packages → preinstalls → Package settings → Manage Actions access → grant write to the \`dogeos69/scroll-sdk\` repo. With that, future re-publishes of the same version would work without a version bump. Optional, but might save the same dance next time someone needs to overwrite a version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)