### PR TITLE
docs: add scroll-reth values examples

### DIFF
--- a/examples/values/README-scroll-reth.md
+++ b/examples/values/README-scroll-reth.md
@@ -1,0 +1,13 @@
+# scroll-reth examples
+
+The default chart values and production examples still use `l2geth`.
+
+Use these opt-in overlays only when testing the DogeOS `scroll-reth` image:
+
+- `l2-sequencer-scroll-reth-production.yaml`
+- `l2-bootnode-scroll-reth-production.yaml`
+- `l2-rpc-scroll-reth-production.yaml`
+
+These examples expect an image that provides `dogeos-reth-entrypoint` and reads
+the `L2RETH_*` environment variables shown in each values file. The genesis
+ConfigMap should expose `genesis.json` generated from `l2reth-genesis.json`.

--- a/examples/values/README-scroll-reth.md
+++ b/examples/values/README-scroll-reth.md
@@ -2,11 +2,15 @@
 
 The default chart values and production examples still use `l2geth`.
 
-Use these opt-in overlays only when testing the DogeOS `scroll-reth` image:
+Use these opt-in replacement values only when testing the DogeOS `scroll-reth`
+image:
 
 - `l2-sequencer-scroll-reth-production.yaml`
 - `l2-bootnode-scroll-reth-production.yaml`
 - `l2-rpc-scroll-reth-production.yaml`
+
+Do not layer these files on top of the `l2geth` production values with multiple
+`-f` flags; Helm deep-merges maps and can retain l2geth-only env/secrets.
 
 These examples expect an image that provides `dogeos-reth-entrypoint` and reads
 the `L2RETH_*` environment variables shown in each values file. The genesis

--- a/examples/values/l2-bootnode-scroll-reth-production.yaml
+++ b/examples/values/l2-bootnode-scroll-reth-production.yaml
@@ -71,5 +71,11 @@ persistence:
     mountPath: /l2reth/genesis/
 
 service:
+  main:
+    enabled: false
   p2p:
     enabled: true
+
+serviceMonitor:
+  main:
+    enabled: false

--- a/examples/values/l2-bootnode-scroll-reth-production.yaml
+++ b/examples/values/l2-bootnode-scroll-reth-production.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/dogeos69/scroll-reth
+  repository: vladogeos/scroll-reth
   pullPolicy: IfNotPresent
   tag: dogeos-revm-c1cd6f4
 

--- a/examples/values/l2-bootnode-scroll-reth-production.yaml
+++ b/examples/values/l2-bootnode-scroll-reth-production.yaml
@@ -1,0 +1,75 @@
+image:
+  repository: ghcr.io/dogeos69/scroll-reth
+  pullPolicy: IfNotPresent
+  tag: dogeos-revm-c1cd6f4
+
+global:
+  fullnameOverride: l2-bootnode-__INSTANCE_INDEX__
+
+command:
+  - bash
+  - -c
+  - exec dogeos-reth-entrypoint
+
+env:
+  - name: RUST_LOG
+    value: sqlx=off,scroll=trace,reth=trace,rollup=trace,info
+
+envFrom:
+  - configMapRef:
+      name: l2-bootnode-__INSTANCE_INDEX__-env
+
+initContainers:
+  wait-for-l1:
+    image: scrolltech/scroll-alpine:v0.0.1
+    command:
+      - /bin/sh
+      - -c
+      - /wait-for-l1.sh $L2RETH_L1_ENDPOINT
+    envFrom:
+      - configMapRef:
+          name: l2-bootnode-__INSTANCE_INDEX__-env
+    volumeMounts:
+      - name: wait-for-l1-script
+        mountPath: /wait-for-l1.sh
+        subPath: wait-for-l1.sh
+
+configMaps:
+  env:
+    enabled: true
+    data:
+      CHAIN_ID: ""
+      L2RETH_ROLE: bootnode
+      L2RETH_DATADIR: /l2reth/reth-data
+      L2RETH_GENESIS: /l2reth/genesis/genesis.json
+      L2RETH_HTTP_PORT: "8545"
+      L2RETH_WS_PORT: "8546"
+      L2RETH_P2P_PORT: "30303"
+      L2RETH_L1_ENDPOINT: "http://l1-interface:8545"
+      L2RETH_BEACON_ENDPOINT: "http://l1-interface:5052"
+      L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: ""
+      L2RETH_VALID_SIGNER: ""
+      L2RETH_PEER_LIST: "[]"
+      L2RETH_EXTRA_PARAMS: ""
+
+persistence:
+  env:
+    enabled: true
+    type: configMap
+    mountPath: /config/
+    name: l2-bootnode-__INSTANCE_INDEX__-env
+  data:
+    enabled: true
+    type: pvc
+    mountPath: /l2reth/reth-data
+    size: 1000Gi
+    retain: true
+  genesis:
+    enabled: true
+    type: configMap
+    name: genesis-config
+    mountPath: /l2reth/genesis/
+
+service:
+  p2p:
+    enabled: true

--- a/examples/values/l2-rpc-scroll-reth-production.yaml
+++ b/examples/values/l2-rpc-scroll-reth-production.yaml
@@ -63,7 +63,15 @@ configMaps:
       L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: ""
       L2RETH_VALID_SIGNER: ""
       L2RETH_PEER_LIST: "[]"
-      L2RETH_EXTRA_PARAMS: ""
+      L2RETH_EXTRA_PARAMS: "--metrics 0.0.0.0:6060"
+
+probes:
+  liveness:
+    enabled: false
+  readiness:
+    enabled: false
+  startup:
+    enabled: false
 
 ingress:
   main:

--- a/examples/values/l2-rpc-scroll-reth-production.yaml
+++ b/examples/values/l2-rpc-scroll-reth-production.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/dogeos69/scroll-reth
+  repository: vladogeos/scroll-reth
   pullPolicy: IfNotPresent
   tag: dogeos-revm-c1cd6f4
 

--- a/examples/values/l2-rpc-scroll-reth-production.yaml
+++ b/examples/values/l2-rpc-scroll-reth-production.yaml
@@ -1,0 +1,92 @@
+image:
+  repository: ghcr.io/dogeos69/scroll-reth
+  pullPolicy: IfNotPresent
+  tag: dogeos-revm-c1cd6f4
+
+global:
+  fullnameOverride: l2-rpc
+
+command:
+  - bash
+  - -c
+  - exec dogeos-reth-entrypoint
+
+env:
+  - name: RUST_LOG
+    value: sqlx=off,scroll=trace,reth=trace,rollup=trace,info
+
+envFrom:
+  - configMapRef:
+      name: l2-rpc-env
+
+initContainers:
+  1-wait-for-l1:
+    image: scrolltech/scroll-alpine:v0.0.1
+    command:
+      - /bin/sh
+      - -c
+      - /wait-for-l1.sh $L2RETH_L1_ENDPOINT
+    envFrom:
+      - configMapRef:
+          name: l2-rpc-env
+    volumeMounts:
+      - name: wait-for-l1-script
+        mountPath: /wait-for-l1.sh
+        subPath: wait-for-l1.sh
+
+volumeClaimTemplates:
+  - name: data
+    accessMode: "ReadWriteOnce"
+    size: "1000Gi"
+    mountPath: "/l2reth/reth-data"
+
+persistence:
+  genesis:
+    enabled: true
+    type: configMap
+    name: genesis-config
+    mountPath: /l2reth/genesis/
+
+configMaps:
+  env:
+    enabled: true
+    data:
+      CHAIN_ID: ""
+      L2RETH_ROLE: rpc
+      L2RETH_DATADIR: /l2reth/reth-data
+      L2RETH_GENESIS: /l2reth/genesis/genesis.json
+      L2RETH_HTTP_PORT: "8545"
+      L2RETH_WS_PORT: "8546"
+      L2RETH_P2P_PORT: "30303"
+      L2RETH_L1_ENDPOINT: "http://l1-interface:8545"
+      L2RETH_BEACON_ENDPOINT: "http://l1-interface:5052"
+      L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: ""
+      L2RETH_VALID_SIGNER: ""
+      L2RETH_PEER_LIST: "[]"
+      L2RETH_EXTRA_PARAMS: ""
+
+ingress:
+  main:
+    ingressClassName: "nginx"
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+  websocket:
+    ingressClassName: "nginx"
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              port: 8546
+
+resources:
+  requests:
+    memory: "1Gi"
+    cpu: "100m"
+  limits:
+    memory: "4Gi"
+    cpu: "1"

--- a/examples/values/l2-sequencer-scroll-reth-production.yaml
+++ b/examples/values/l2-sequencer-scroll-reth-production.yaml
@@ -1,0 +1,80 @@
+image:
+  repository: ghcr.io/dogeos69/scroll-reth
+  pullPolicy: IfNotPresent
+  tag: dogeos-revm-c1cd6f4
+
+global:
+  fullnameOverride: l2-sequencer-__INSTANCE_INDEX__
+
+command:
+  - bash
+  - -c
+  - exec dogeos-reth-entrypoint
+
+env:
+  - name: RUST_LOG
+    value: sqlx=off,scroll=trace,reth=trace,rollup=trace,info
+
+envFrom:
+  - configMapRef:
+      name: l2-sequencer-__INSTANCE_INDEX__-env
+
+initContainers:
+  wait-for-l1:
+    image: scrolltech/scroll-alpine:v0.0.1
+    command:
+      - /bin/sh
+      - -c
+      - /wait-for-l1.sh $L2RETH_L1_ENDPOINT
+    envFrom:
+      - configMapRef:
+          name: l2-sequencer-__INSTANCE_INDEX__-env
+    volumeMounts:
+      - name: wait-for-l1-script
+        mountPath: /wait-for-l1.sh
+        subPath: wait-for-l1.sh
+
+configMaps:
+  env:
+    enabled: true
+    data:
+      CHAIN_ID: ""
+      L2RETH_ROLE: sequencer
+      L2RETH_DATADIR: /l2reth/reth-data
+      L2RETH_GENESIS: /l2reth/genesis/genesis.json
+      L2RETH_HTTP_PORT: "8545"
+      L2RETH_WS_PORT: "8546"
+      L2RETH_P2P_PORT: "30303"
+      L2RETH_L1_ENDPOINT: "http://l1-interface:8545"
+      L2RETH_BEACON_ENDPOINT: "http://l1-interface:5052"
+      L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: ""
+      L2RETH_VALID_SIGNER: ""
+      L2RETH_PEER_LIST: "[]"
+      L2RETH_EXTRA_PARAMS: ""
+
+persistence:
+  env:
+    enabled: true
+    type: configMap
+    name: l2-sequencer-__INSTANCE_INDEX__-env
+  data:
+    enabled: true
+    type: pvc
+    name: l2reth-data
+    mountPath: /l2reth/reth-data
+    size: 1000Gi
+    retain: true
+  genesis:
+    enabled: true
+    type: configMap
+    name: genesis-config
+    mountPath: /l2reth/genesis/genesis.json
+    subPath: genesis.json
+
+resources:
+  requests:
+    memory: "150Mi"
+    cpu: "50m"
+  limits:
+    memory: "8Gi"
+    cpu: "4"

--- a/examples/values/l2-sequencer-scroll-reth-production.yaml
+++ b/examples/values/l2-sequencer-scroll-reth-production.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/dogeos69/scroll-reth
+  repository: vladogeos/scroll-reth
   pullPolicy: IfNotPresent
   tag: dogeos-revm-c1cd6f4
 

--- a/examples/values/l2-sequencer-scroll-reth-production.yaml
+++ b/examples/values/l2-sequencer-scroll-reth-production.yaml
@@ -50,7 +50,15 @@ configMaps:
       L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: ""
       L2RETH_VALID_SIGNER: ""
       L2RETH_PEER_LIST: "[]"
-      L2RETH_EXTRA_PARAMS: ""
+      L2RETH_EXTRA_PARAMS: "--metrics 0.0.0.0:6060"
+
+probes:
+  liveness:
+    enabled: false
+  readiness:
+    enabled: false
+  startup:
+    enabled: false
 
 persistence:
   env:


### PR DESCRIPTION
## Summary
- add opt-in `scroll-reth` example values for l2-sequencer, l2-bootnode, and l2-rpc
- keep chart defaults and existing production examples on `l2geth`
- document the expected `dogeos-reth-entrypoint` / `L2RETH_*` contract for examples

Linear: [DOG-384](https://linear.app/dogeos69/issue/DOG-384/add-opt-in-scroll-reth-dogeos-revm-backend)

## Testing
- `helm dependency build charts/l2-sequencer`
- `helm dependency build charts/l2-bootnode`
- `helm dependency build charts/l2-rpc`
- `helm template` for default and scroll-reth overlays for sequencer, bootnode, and RPC

## Notes
- These are example overlays only; chart defaults remain unchanged.
