### PR TITLE
[codex] add proof-coordinator chart

### DIFF
--- a/charts/l2-reth/Chart.yaml
+++ b/charts/l2-reth/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: l2 reth rollup node chart
 name: l2-reth
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:

--- a/charts/l2-reth/templates/_helpers.tpl
+++ b/charts/l2-reth/templates/_helpers.tpl
@@ -167,6 +167,34 @@ probes:
 {{- end -}}
 
 {{/*
+Render l2-reth container ports explicitly. The common chart derives container
+ports from every enabled Service port, which duplicates the P2P container ports
+when a bootnode has both an internal P2P Service and an external P2P
+LoadBalancer Service.
+*/}}
+{{- define "scroll.common.lib.container.ports" -}}
+{{- if .Values.reth.http.enabled }}
+- name: http
+  containerPort: {{ .Values.reth.ports.http }}
+  protocol: TCP
+{{- end }}
+{{- if .Values.reth.ws.enabled }}
+- name: ws
+  containerPort: {{ .Values.reth.ports.ws }}
+  protocol: TCP
+{{- end }}
+- name: metrics
+  containerPort: {{ .Values.reth.ports.metrics }}
+  protocol: TCP
+- name: p2p-tcp
+  containerPort: {{ .Values.reth.ports.p2p }}
+  protocol: TCP
+- name: p2p-udp
+  containerPort: {{ .Values.reth.ports.p2p }}
+  protocol: UDP
+{{- end -}}
+
+{{/*
 Generate rollup-node argv without shell interpolation.
 */}}
 {{- define "l2-reth.extraArgs" -}}

--- a/charts/proof-coordinator/.helmignore
+++ b/charts/proof-coordinator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building Helm packages.
+# https://helm.sh/docs/topics/charts/#the-helmignore-file
+.DS_Store
+# Version control
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+# Common backup / editor files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# CI / IDE
+.idea/
+.vscode/
+.project
+# Charts index / repo metadata (not part of the packaged chart)
+index.yaml

--- a/charts/proof-coordinator/Chart.yaml
+++ b/charts/proof-coordinator/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: proof-coordinator
+description: A Helm chart for the DogeOS proof-coordinator service
+type: application
+version: 0.2.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.22.0-0"
+home: https://github.com/DogeOS69/dogeos-core
+sources:
+  - https://github.com/DogeOS69/dogeos-core/tree/develop/crates/proof_coordinator
+keywords:
+  - dogeos
+  - scroll
+  - proof-coordinator
+  - zk
+  - bridge
+maintainers:
+  - name: DogeOS69
+    email: support@dogeos.com
+
+dependencies:
+  - name: common
+    repository: "oci://ghcr.io/scroll-tech/scroll-sdk/helm"
+    version: 1.5.1
+  - name: external-secrets-lib
+    repository: "oci://ghcr.io/dogeos69/scroll-sdk/helm"
+    version: 0.0.4

--- a/charts/proof-coordinator/README.md
+++ b/charts/proof-coordinator/README.md
@@ -1,0 +1,123 @@
+# proof-coordinator
+
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+A Helm chart for the DogeOS proof-coordinator service
+
+**Homepage:** <https://github.com/DogeOS69/dogeos-core>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| DogeOS69 | <support@dogeos.com> |  |
+
+## Source Code
+
+* <https://github.com/DogeOS69/dogeos-core/tree/develop/crates/proof_coordinator>
+
+## Requirements
+
+Kubernetes: `>=1.22.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://ghcr.io/dogeos69/scroll-sdk/helm | external-secrets-lib | 0.0.4 |
+| oci://ghcr.io/scroll-tech/scroll-sdk/helm | common | 1.5.1 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| command[0] | string | `"sh"` |  |
+| command[1] | string | `"-ec"` |  |
+| command[2] | string | `"mkdir -p /app/data/proof-artifacts && exec proof-coordinator --config /app/conf/ProofCoordinator.toml"` |  |
+| configMaps.config.data."ProofCoordinator.toml" | string | `"proof_work_base_url = \"http://127.0.0.1:9300\"\ncoordinator_id = \"proof-coordinator\"\npoll_interval_ms = 1000\nlease_ttl_ms = 60000\n\n[artifact_store]\nkind = \"local_fs\"\nroot = \"/app/data/proof-artifacts\"\n\n[verifier]\nverifier_import_mode = \"dev_dummy\"\n"` |  |
+| configMaps.config.enabled | bool | `true` |  |
+| controller.replicas | int | `1` |  |
+| controller.strategy | string | `"RollingUpdate"` |  |
+| controller.type | string | `"statefulset"` |  |
+| defaultProbes.custom | bool | `true` |  |
+| defaultProbes.enabled | bool | `false` |  |
+| defaultProbes.spec.failureThreshold | int | `3` |  |
+| defaultProbes.spec.httpGet.path | string | `"/healthz"` |  |
+| defaultProbes.spec.httpGet.port | string | `"http"` |  |
+| defaultProbes.spec.periodSeconds | int | `10` |  |
+| defaultProbes.spec.timeoutSeconds | int | `2` |  |
+| env | list | `[]` |  |
+| envFrom | list | `[]` |  |
+| externalSecrets | object | `{}` |  |
+| global.fullnameOverride | string | `"proof-coordinator"` |  |
+| global.nameOverride | string | `"proof-coordinator"` |  |
+| image.pullPolicy | string | `"Always"` |  |
+| image.repository | string | `"dogeos69/proof-coordinator"` |  |
+| image.tag | string | `"latest"` |  |
+| ingress.main.enabled | bool | `false` |  |
+| persistence.config.enabled | bool | `true` |  |
+| persistence.config.mountPath | string | `"/app/conf/"` |  |
+| persistence.config.name | string | `"proof-coordinator-config"` |  |
+| persistence.config.type | string | `"configMap"` |  |
+| persistence.data.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.data.enabled | bool | `true` |  |
+| persistence.data.mountPath | string | `"/app/data"` |  |
+| persistence.data.name | string | `"proof-coordinator-data-pvc"` |  |
+| persistence.data.retain | bool | `true` |  |
+| persistence.data.size | string | `"10Gi"` |  |
+| persistence.data.type | string | `"pvc"` |  |
+| persistence.secrets.enabled | bool | `false` |  |
+| persistence.secrets.mountPath | string | `"/run/secrets"` |  |
+| persistence.secrets.name | string | `"proof-coordinator-secrets"` |  |
+| persistence.secrets.readOnly | bool | `true` |  |
+| persistence.secrets.type | string | `"secret"` |  |
+| persistence.tmp.enabled | bool | `true` |  |
+| persistence.tmp.mountPath | string | `"/tmp"` |  |
+| persistence.tmp.sizeLimit | string | `"1Gi"` |  |
+| persistence.tmp.type | string | `"emptyDir"` |  |
+| podSecurityContext.fsGroup | int | `65532` |  |
+| podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
+| podSecurityContext.runAsGroup | int | `65532` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.runAsUser | int | `65532` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| probes.liveness.<<.custom | bool | `true` |  |
+| probes.liveness.<<.enabled | bool | `false` |  |
+| probes.liveness.<<.spec.failureThreshold | int | `3` |  |
+| probes.liveness.<<.spec.httpGet.path | string | `"/healthz"` |  |
+| probes.liveness.<<.spec.httpGet.port | string | `"http"` |  |
+| probes.liveness.<<.spec.periodSeconds | int | `10` |  |
+| probes.liveness.<<.spec.timeoutSeconds | int | `2` |  |
+| probes.readiness.<<.custom | bool | `true` |  |
+| probes.readiness.<<.enabled | bool | `false` |  |
+| probes.readiness.<<.spec.failureThreshold | int | `3` |  |
+| probes.readiness.<<.spec.httpGet.path | string | `"/healthz"` |  |
+| probes.readiness.<<.spec.httpGet.port | string | `"http"` |  |
+| probes.readiness.<<.spec.periodSeconds | int | `10` |  |
+| probes.readiness.<<.spec.timeoutSeconds | int | `2` |  |
+| probes.startup.<<.custom | bool | `true` |  |
+| probes.startup.<<.enabled | bool | `false` |  |
+| probes.startup.<<.spec.failureThreshold | int | `3` |  |
+| probes.startup.<<.spec.httpGet.path | string | `"/healthz"` |  |
+| probes.startup.<<.spec.httpGet.port | string | `"http"` |  |
+| probes.startup.<<.spec.periodSeconds | int | `10` |  |
+| probes.startup.<<.spec.timeoutSeconds | int | `2` |  |
+| probes.startup.spec.failureThreshold | int | `24` |  |
+| probes.startup.spec.httpGet.path | string | `"/healthz"` |  |
+| probes.startup.spec.httpGet.port | string | `"http"` |  |
+| probes.startup.spec.periodSeconds | int | `5` |  |
+| probes.startup.spec.timeoutSeconds | int | `2` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.limits.memory | string | `"1Gi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"256Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| service.main.enabled | bool | `false` |  |
+| service.main.ports.http.enabled | bool | `true` |  |
+| service.main.ports.http.port | int | `9400` |  |
+| service.main.ports.http.protocol | string | `"TCP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `"proof-coordinator"` |  |
+| serviceMonitor.main.enabled | bool | `false` |  |
+

--- a/charts/proof-coordinator/templates/common.yaml
+++ b/charts/proof-coordinator/templates/common.yaml
@@ -1,0 +1,17 @@
+---
+{{- include "scroll.common.loader.init" . }}
+
+{{- define "app-template.hardcodedValues" -}}
+# Set the nameOverride based on the release name if no override has been set
+{{ if not .Values.global.nameOverride }}
+global:
+  nameOverride: "{{ .Release.Name }}"
+{{ end }}
+{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "app-template.hardcodedValues" . | fromYaml) -}}
+
+{{/* Render the templates */}}
+{{ include "scroll.common.loader.generate" . }}
+---
+{{/* Explicitly include the template to render ExternalSecret resources */}}
+{{- include "scrolllib.externalsecrets.tpl" . }}

--- a/charts/proof-coordinator/values.schema.json
+++ b/charts/proof-coordinator/values.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "controller": {
+      "type": "object",
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "proof-coordinator is singleton-only: it holds work leases under a single coordinator_id and its artifact store / data PVC are ReadWriteOnce. Do not run multiple replicas."
+        }
+      }
+    }
+  }
+}

--- a/charts/proof-coordinator/values.yaml
+++ b/charts/proof-coordinator/values.yaml
@@ -1,0 +1,160 @@
+global:
+  nameOverride: &app_name proof-coordinator
+  fullnameOverride: *app_name
+
+controller:
+  type: statefulset
+  replicas: 1
+  strategy: RollingUpdate
+
+image:
+  repository: dogeos69/proof-coordinator
+  pullPolicy: Always
+  tag: latest
+
+# Dedicated ServiceAccount. Keeping a per-workload identity (rather than the
+# namespace `default`) is required for cloud IAM binding — e.g. AWS IRSA for the
+# S3 artifact store: set `serviceAccount.annotations.eks.amazonaws.com/role-arn`
+# (see values/production.yaml).
+serviceAccount:
+  create: true
+  name: proof-coordinator
+  annotations: {}
+
+command:
+  - "sh"
+  - "-ec"
+  - "mkdir -p /app/data/proof-artifacts && exec proof-coordinator --config /app/conf/ProofCoordinator.toml"
+
+service:
+  main:
+    enabled: false
+    ports:
+      http:
+        enabled: true
+        port: 9400
+        protocol: TCP
+
+defaultProbes: &default_probes
+  enabled: false
+  custom: true
+  spec:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+probes:
+  liveness:
+    <<: *default_probes
+  readiness:
+    <<: *default_probes
+  startup:
+    <<: *default_probes
+    spec:
+      httpGet:
+        path: /healthz
+        port: http
+      periodSeconds: 5
+      timeoutSeconds: 2
+      failureThreshold: 24
+
+persistence:
+  config:
+    enabled: true
+    type: configMap
+    mountPath: /app/conf/
+    # Rendered by the common library from `configMaps.config` below as
+    # <fullname>-config; changes roll pods via the checksum/config annotation.
+    name: proof-coordinator-config
+  data:
+    enabled: true
+    name: proof-coordinator-data-pvc
+    type: pvc
+    mountPath: /app/data
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    retain: true
+  secrets:
+    enabled: false
+    type: secret
+    mountPath: /run/secrets
+    name: proof-coordinator-secrets
+    readOnly: true
+  # Writable scratch space so the container can run with a read-only root
+  # filesystem (see securityContext.readOnlyRootFilesystem). Sized small; all
+  # durable state lives on the `data` PVC.
+  tmp:
+    enabled: true
+    type: emptyDir
+    mountPath: /tmp
+    sizeLimit: 1Gi
+
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "100m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"
+
+# Pod-level hardening. The runtime image (debian-slim) ships no non-root USER,
+# so we pin an unprivileged UID/GID here; the binary is world-executable and
+# only writes to the `data` PVC, whose ownership fsGroup fixes up on mount.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level hardening. Durable state is on the `data` PVC and scratch on
+# the `tmp` emptyDir, so the root filesystem can be read-only.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+serviceMonitor:
+  main:
+    enabled: false
+
+ingress:
+  main:
+    enabled: false
+
+# Per-deployment scalar overrides. The binary layers
+# `DOGEOS_PROOF_COORDINATOR_*` env vars (Figment, `__` = section separator) on
+# top of ProofCoordinator.toml, so deployment-specific values belong here —
+# tooling (scroll-sdk-cli) should emit these instead of rewriting the TOML.
+# e.g. DOGEOS_PROOF_COORDINATOR_ARTIFACT_STORE__BUCKET=my-bucket
+env: []
+envFrom: []
+externalSecrets: {}
+
+configMaps:
+  config:
+    enabled: true
+    data:
+      # Static baseline configuration. Dev/regtest verify-only defaults;
+      # values/production.yaml replaces this with the production posture
+      # (auth, S3 store, verifier identity pins, prover_api) and moves the
+      # per-deployment scalars to `env` above.
+      ProofCoordinator.toml: |
+        proof_work_base_url = "http://127.0.0.1:9300"
+        coordinator_id = "proof-coordinator"
+        poll_interval_ms = 1000
+        lease_ttl_ms = 60000
+
+        [artifact_store]
+        kind = "local_fs"
+        root = "/app/data/proof-artifacts"
+
+        [verifier]
+        verifier_import_mode = "dev_dummy"

--- a/charts/proof-coordinator/values/production.yaml
+++ b/charts/proof-coordinator/values/production.yaml
@@ -1,0 +1,211 @@
+---
+# Production-oriented overrides for proof-coordinator. Replace every <TODO>
+# before deploying; the service fails closed on malformed verifier pins, missing
+# secret files, unsafe plaintext posture, and invalid worker-visible URLs.
+#
+# Layering contract (Figment in the binary: TOML file, then env overlay):
+#   - configMaps.config (ProofCoordinator.toml): static production posture +
+#     deep verifier/materializer structure. Hand-maintained.
+#   - env (DOGEOS_PROOF_COORDINATOR_*): per-deployment scalars. This is the
+#     part deployment tooling (scroll-sdk-cli) generates; `__` separates TOML
+#     sections, e.g. ARTIFACT_STORE__BUCKET -> [artifact_store] bucket.
+#   - secrets: mounted files via externalSecrets, referenced by *_file keys.
+image:
+  repository: dogeos69/proof-coordinator
+  pullPolicy: IfNotPresent
+  tag: latest
+
+service:
+  main:
+    enabled: true
+    ports:
+      http:
+        enabled: true
+        port: 9400
+        protocol: TCP
+
+probes:
+  liveness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /healthz
+        port: http
+      periodSeconds: 15
+      timeoutSeconds: 2
+      failureThreshold: 3
+  readiness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /healthz
+        port: http
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 3
+  startup:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /healthz
+        port: http
+      periodSeconds: 5
+      timeoutSeconds: 2
+      failureThreshold: 60
+
+persistence:
+  secrets:
+    enabled: true
+    type: secret
+    mountPath: /run/secrets
+    name: proof-coordinator-secrets
+    readOnly: true
+
+# Grant the pod's ServiceAccount an AWS IAM role via IRSA so the S3 artifact
+# store needs no static credentials. Uncomment and set the role ARN; leave the
+# annotations empty and use env/envFrom below for MinIO or static credentials.
+serviceAccount:
+  create: true
+  name: proof-coordinator
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<TODO>
+
+# Per-deployment scalars, layered over ProofCoordinator.toml by the binary's
+# DOGEOS_PROOF_COORDINATOR_ env overlay. Generated/owned by deployment tooling.
+# For MinIO or static S3 credentials additionally inject AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY / AWS_REGION (via secretKeyRef or envFrom); with IRSA
+# none are needed.
+env:
+  # WP proof-work API base URL. `allow_insecure_http` is required for a
+  # non-loopback http:// URL — prefer https:// or service-mesh TLS if the
+  # network path is not private/trusted.
+  - name: DOGEOS_PROOF_COORDINATOR_PROOF_WORK_BASE_URL
+    value: "http://withdrawal-processor:3000"
+  - name: DOGEOS_PROOF_COORDINATOR_ALLOW_INSECURE_HTTP
+    value: "true"
+  - name: DOGEOS_PROOF_COORDINATOR_COORDINATOR_ID
+    value: "proof-coordinator"
+  # [artifact_store] S3 location.
+  - name: DOGEOS_PROOF_COORDINATOR_ARTIFACT_STORE__BUCKET
+    value: "<TODO>"
+  - name: DOGEOS_PROOF_COORDINATOR_ARTIFACT_STORE__REGION
+    value: "us-west-2"
+  # Internal coordinator/WP/SDK endpoint; omit this entry for AWS S3.
+  - name: DOGEOS_PROOF_COORDINATOR_ARTIFACT_STORE__ENDPOINT_URL
+    value: "<TODO>"
+  # Worker-visible S3 endpoint. Required when artifact_store.endpoint_url is
+  # not directly acceptable to remote workers. Must be https://, unless it is
+  # exactly http://127.0.0.1.
+  - name: DOGEOS_PROOF_COORDINATOR_PROVER_API__PUBLIC_S3_ENDPOINT_URL
+    value: "<TODO>"
+envFrom: []
+
+externalSecrets:
+  proof-coordinator-secrets:
+    provider: aws
+    data:
+      - remoteRef:
+          key: scroll/proof-coordinator-secrets
+          property: proof-work-token
+        secretKey: proof-work-token
+      - remoteRef:
+          key: scroll/proof-coordinator-secrets
+          property: prover-worker-token
+        secretKey: prover-worker-token
+    refreshInterval: 2m
+    serviceAccount: external-secrets
+
+# Static production posture. Per-deployment scalars (URLs, bucket, region,
+# coordinator id) intentionally do NOT appear here — they come from `env`
+# above. Verifier identity pins are per-network but deep/structural, so they
+# stay in TOML where a family is one reviewable block.
+configMaps:
+  config:
+    enabled: true
+    data:
+      ProofCoordinator.toml: |
+        poll_interval_ms = 1000
+        lease_ttl_ms = 60000
+
+        [auth]
+        bearer_token_file = "/run/secrets/proof-work-token"
+
+        [artifact_store]
+        kind = "s3"
+        key_prefix = "proof-topology"
+        force_path_style = true          # typical for MinIO; set false/omit for AWS S3
+
+        [verifier]
+        verifier_import_mode = "production"
+
+        [verifier.scroll_chunk_verifier_identity]
+        program_manifest_path = "/app/data/manifests/scroll-chunk.json"
+        expected_proof_system_id = "<TODO>"
+        expected_circuit_id = "<TODO>"
+        expected_circuit_version = "<TODO>"
+        expected_verification_key_hash_hex = "<TODO>"
+        expected_program_commitment_hash_hex = "<TODO>"
+        verifier_id = "<TODO>"
+
+        [verifier.scroll_batch_verifier_identity]
+        program_manifest_path = "/app/data/manifests/scroll-batch.json"
+        expected_proof_system_id = "<TODO>"
+        expected_circuit_id = "<TODO>"
+        expected_circuit_version = "<TODO>"
+        expected_verification_key_hash_hex = "<TODO>"
+        expected_program_commitment_hash_hex = "<TODO>"
+        verifier_id = "<TODO>"
+
+        # Enable when bridge proof verification/materialization is part of this
+        # environment, and set bridge_program_commitment_hex below.
+        # [verifier.scroll_bridge_verifier_identity]
+        # program_manifest_path = "/app/data/manifests/scroll-bridge.json"
+        # expected_proof_system_id = "<TODO>"
+        # expected_circuit_id = "<TODO>"
+        # expected_circuit_version = "<TODO>"
+        # expected_verification_key_hash_hex = "<TODO>"
+        # expected_program_commitment_hash_hex = "<TODO>"
+        # verifier_id = "<TODO>"
+
+        [verifier.scroll_real_verifier]
+        agg_verifying_key_path = "/app/data/verifier/agg-vk.bin"
+        chunk_program_commitment_hex = "<TODO>"
+        batch_program_commitment_hex = "<TODO>"
+        # bridge_program_commitment_hex = "<TODO>"
+
+        # Optional materializer execution config. Leave absent for verify +
+        # prover gateway only. Uncomment and fill the family blocks this
+        # deployment owns.
+        #
+        # [materializer.scroll_chunk]
+        # enabled = true
+        # binary_path = "/opt/dogeos/materialize-chunk-oneshot"
+        # statement_namespace_config_path = "/app/data/statement-namespace.json"
+        # sidecar_scratch_root = "/app/data/chunk-scratch"
+        # l2_rpc_url = "http://l2-rpc:8545"
+        # subprocess_timeout_ms = 600000
+        # [materializer.scroll_chunk.prove_spec]
+        # backend_profile = "scroll-prod-zkvm-v1"
+        #
+        # [materializer.scroll_batch]
+        # enabled = true
+        # dev_sentinel = false
+        # materializer_output_root = "/app/data/batch-output"
+        # proof_mode = "Production"
+
+        [prover_api]
+        enabled = true
+        bind_addr = "0.0.0.0:9400"
+        worker_auth_token_file = "/run/secrets/prover-worker-token"
+        max_lease_ttl_ms = 60000
+        transport = "s3"
+
+        [artifact_write]
+        signed_put_expiry_ms = 3600000
+        staging_prefix = "staging/proofs"
+        accepted_prefix = "accepted/proofs"
+        max_proof_bytes = 536870912
+        max_public_output_bytes = 10485760

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -66,7 +66,7 @@ install-l2-rpc:
 
 install-l2-reth:
 	helm upgrade -i l2-reth-rpc oci://ghcr.io/dogeos69/scroll-sdk/helm/l2-reth -n $(NAMESPACE) \
-		--version=0.1.0 \
+		--version=0.1.1 \
 		--values values/l2-reth-production.yaml
 
 install-l2-sequencer:

--- a/examples/values/l2-reth-bootnode-production.yaml
+++ b/examples/values/l2-reth-bootnode-production.yaml
@@ -90,7 +90,6 @@ reth:
     feeRecipient: "<TODO>"
 
   rpc:
-    sequencerUrl: ""
     trustedOnly: false
     maxOutboundPeers: ""
     maxInboundPeers: ""

--- a/examples/values/l2-reth-rpc-production.yaml
+++ b/examples/values/l2-reth-rpc-production.yaml
@@ -97,7 +97,6 @@ reth:
     feeRecipient: "<TODO>"
 
   rpc:
-    sequencerUrl: "http://l2-reth-sequencer-0:8545"
     trustedOnly: false
     maxOutboundPeers: ""
     maxInboundPeers: ""

--- a/examples/values/l2-reth-sequencer-production.yaml
+++ b/examples/values/l2-reth-sequencer-production.yaml
@@ -90,7 +90,6 @@ reth:
     feeRecipient: "<TODO>"
 
   rpc:
-    sequencerUrl: ""
     trustedOnly: false
     maxOutboundPeers: ""
     maxInboundPeers: ""


### PR DESCRIPTION
## Summary

- Add a Helm chart for the DogeOS proof-coordinator service.
- Add default and production values, schema validation, ExternalSecret rendering, and chart documentation.
- Override l2-reth container port rendering to avoid duplicate P2P container ports when bootnodes expose internal and external P2P services.
- Remove hard-coded l2-reth example sequencer URLs already covered by generated configuration.

## Validation

- helm dependency build charts/proof-coordinator
- helm dependency build charts/l2-reth
- helm lint charts/proof-coordinator
- helm lint charts/proof-coordinator -f charts/proof-coordinator/values/production.yaml
- helm lint charts/l2-reth
- helm template proof-coordinator charts/proof-coordinator -f charts/proof-coordinator/values/production.yaml
- helm template l2-reth charts/l2-reth

Note: local chart-testing (`ct`) is not installed in this environment, so GitHub Actions remains the authoritative `ct lint` run.
